### PR TITLE
Expose package.json in components' docs page scopes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2.1
+orbs:
+  node: circleci/node@3.0.0
+workflows:
+  test:
+    jobs:
+      - node/test:
+          run-command: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ workflows:
   test:
     jobs:
       - node/test:
-          run-command: npm run test
+          run-command: test

--- a/example/components/button/docs.mdx
+++ b/example/components/button/docs.mdx
@@ -12,3 +12,9 @@ This is the docs for the button component
 <PropsTable props={componentProps} />
 
 <Tester />
+
+## Exposed `package.json`
+
+<pre>
+  <code>{JSON.stringify(packageJson, null, 2)}</code>
+</pre>

--- a/example/components/button/package.json
+++ b/example/components/button/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@some-org/react-button",
+  "description": "A clickable text box that allows a user to take an action.",
+  "version": "1.0.0",
+  "author": "SomeOrg",
+  "contributors": [
+    "Jamie Appleseed"
+  ],
+  "dependencies": {},
+  "license": "MPL-2.0",
+  "peerDependencies": {
+    "react": "^16.9.0"
+  }
+}

--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import matter from 'gray-matter'
 import { existsSync } from 'fsexists'
 import requireFromString from 'require-from-string'
@@ -17,7 +18,7 @@ export default function createStaticProps(swingsetOptions = {}) {
         fs.readFileSync(component.docsPath, 'utf8')
       )
       //  Read and parse the component's package.json, if possible
-      const pathToPackageJson = component.path + '/package.json'
+      const pathToPackageJson = path.join(component.path, 'package.json')
       const packageJson = existsSync(pathToPackageJson)
         ? JSON.parse(fs.readFileSync(pathToPackageJson, 'utf8'))
         : undefined


### PR DESCRIPTION
This PR exposes `package.json` data to the docs page scope of each component.

It does this by trying to read and parse `${component.path}/package.json`. If this file is present and is valid `json`, then its contents will be exposed in the docs page scope as `packageJson` (similar to the exposure of `componentProps`).

If the `package.json` file is not present, then `packageJson` in the docs page scope will be undefined. If the `package.json` file is present but is not valid `json`, then `swingset` will throw an error.