### PR TITLE
Fix issues with packageJson

### DIFF
--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -21,7 +21,7 @@ export default function createStaticProps(swingsetOptions = {}) {
       const pathToPackageJson = path.join(component.path, 'package.json')
       const packageJson = existsSync(pathToPackageJson)
         ? JSON.parse(fs.readFileSync(pathToPackageJson, 'utf8'))
-        : undefined
+        : null
 
       // Check for a file called 'props.json5' - if it exists, we import it as `props`
       // to the mdx file. This is a nice pattern for knobs and props tables.
@@ -54,7 +54,7 @@ export default function createStaticProps(swingsetOptions = {}) {
             scope: {
               componentProps: props
                 ? requireFromString(props, propsPath)
-                : undefined,
+                : null,
               packageJson,
             },
           }).then((res) => [name, res])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swingset",
-  "version": "0.5.0",
+  "version": "0.5.0-canary.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test": "jest",
     "release:major": "release major && npm publish",
     "release:minor": "release minor && npm publish",
-    "release:patch": "release patch && npm publish"
+    "release:patch": "release patch && npm publish",
+    "release:pre": "release pre canary && npm publish --tag=canary"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swingset",
   "description": "drop-in component library and documentation pages for next.js",
-  "version": "0.5.0",
+  "version": "0.5.0-canary.0",
   "author": "Jeff Escalante",
   "bugs": {
     "url": "https://github.com/hashicorp/swingset/issues"


### PR DESCRIPTION
Went to use `0.5.0` in `react-components` and immediately realized I'd borked some things in #13. This PR fixes those things.

It also adds a `release:pre` script to make it easier to cut pre-releases. I've tested a pre-release with the patches in this PR in [`react-components#124`](https://github.com/hashicorp/react-components/pull/124).