### PR TITLE
fix: move sidebar styles so the full list element is clickable

### DIFF
--- a/style.module.css
+++ b/style.module.css
@@ -39,22 +39,19 @@
   right: 0;
 }
 
-.sidebar li {
-  cursor: pointer;
-  padding: 10px 30px 10px 25px;
-  border-left: 5px solid transparent;
-}
-
-.sidebar li.active {
+.sidebar li.active a {
   border-left: 5px solid rgba(255, 237, 114, 0.8);
   background: rgba(255, 255, 255, 0.05);
 }
 
-.sidebar li:hover {
+.sidebar li a:hover {
   background: rgba(255, 255, 255, 0.1);
 }
 
 .sidebar li a {
+  border-left: 5px solid transparent;
+  padding: 10px 30px 10px 25px;
+  display: block;
   color: white;
 }
 


### PR DESCRIPTION
Good catch by @zchsh! When I added an anchor element into the sidebar `li` the full visual element wasn't clickable. Adjusted styling so anywhere you click is the link.