### PR TITLE
bugfix: remove hardcoded `/` from page route

### DIFF
--- a/utils/url-state.js
+++ b/utils/url-state.js
@@ -21,7 +21,7 @@ export function setUrlState(component, id, values, copyToClipboard) {
     values: values && encode(JSON.stringify(values))
   })
 
-  Router.push(`/?${qs}`)
+  Router.push(`?${qs}`)
 
   if (copyToClipboard) copy(window.location.href)
 }


### PR DESCRIPTION
* enables swingset to be properly confiugured on a non-index route eg `/components`