### PR TITLE
Add mdx options to `createStaticProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ module.exports = withSwingset(/* swingset options */)(/* normal nextjs config */
 
 You then need to create a page in your nextjs app where swingset will live. You can "inject" swingset on to any page of your choosing. Something like `/components` might be a nice choice. When you have decided on a page, swingset can be injected as follows:
 
+> **Note:** `createStaticProps` accepts `mdxOptions`, which allow you to customize how your markup is rendered. For details, see [`next-mdx-remote`](https://github.com/hashicorp/next-mdx-remote/blob/main/render-to-string.d.ts#L36-L42)
+
 ```jsx
 import createPage from 'swingset/page'
 import createStaticProps from 'swingset/getStaticProps'
 
 export default createPage()
-export const getStaticProps = createStaticProps()
+export const getStaticProps = createStaticProps({ /* mdxOptions = {} */})
 ```
 
 With this in place, if you go to the page you injected it on, it should work, although it will be empty. Next, let's talk about how to get some components loaded in there.

--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -57,6 +57,7 @@ export default function createStaticProps(swingsetOptions = {}) {
                 : null,
               packageJson,
             },
+            mdxOptions: swingsetOptions.mdxOptions || {},
           }).then((res) => [name, res])
           // transform to an object for easier name/component mapping on the client side
         }


### PR DESCRIPTION
Enables consumers to supply `mdxOptions` to `createStaticProps`. 

Use cases include: applying any of our internal remark / rehype plugins. [On learn](https://github.com/hashicorp/learn/pull/3124/commits/6bc04abd7f801130a6b1e7c95d4bc5771f635591#diff-8ab0398cb55afb95f74d08c55474623b161c2a948d7b72dc8d0a2ae9bb3ce90a), we're using it to add anchor links, custom alerts, and code highlighting.