### PR TITLE
Remove base styling

### DIFF
--- a/components/props-table/style.module.css
+++ b/components/props-table/style.module.css
@@ -4,6 +4,15 @@
   color: #212529;
   border-collapse: collapse;
   border: 1px solid #dee2e6;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.625;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
 }
 
 .root th,

--- a/components/shared.module.css
+++ b/components/shared.module.css
@@ -7,6 +7,14 @@
   border-bottom: 1px solid #eee;
   padding-bottom: 2px;
   overflow: hidden;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.625;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
 }
 
 .save {
@@ -26,6 +34,14 @@
   cursor: pointer;
   transition: opacity 0.25s ease;
   z-index: 9999;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.625;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
 }
 
 .save:hover {

--- a/examples/basic/package-lock.json
+++ b/examples/basic/package-lock.json
@@ -4332,11 +4332,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -6731,7 +6726,7 @@
       }
     },
     "swingset": {
-      "version": "file:..",
+      "version": "file:../..",
       "requires": {
         "copy-text-to-clipboard": "^2.2.0",
         "fsexists": "^1.0.1",
@@ -7235,20 +7230,7 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.12.9",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
-              "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "convert-source-map": "^1.7.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.1",
-                "json5": "^2.1.2",
-                "lodash": "^4.17.19",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
-              }
+              "version": ""
             }
           }
         },
@@ -7285,20 +7267,7 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.12.9",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
-              "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-              "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "convert-source-map": "^1.7.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.1",
-                "json5": "^2.1.2",
-                "lodash": "^4.17.19",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
-              }
+              "version": ""
             }
           }
         },
@@ -7849,24 +7818,23 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@jest/console": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-          "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.6.1.tgz",
+          "integrity": "sha512-cjqcXepwC5M+VeIhwT6Xpi/tT4AiNzlIx8SMJ9IihduHnsSrnWNvTBfKIpmqOOCNOPqtbBx6w2JqfoLOJguo8g==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
-            "jest-message-util": "^26.3.0",
-            "jest-util": "^26.3.0",
+            "jest-message-util": "^26.6.1",
+            "jest-util": "^26.6.1",
             "slash": "^3.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -7898,9 +7866,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -7908,33 +7876,33 @@
           }
         },
         "@jest/core": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-          "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.6.1.tgz",
+          "integrity": "sha512-p4F0pgK3rKnoS9olXXXOkbus1Bsu6fd8pcvLMPsUy4CVXZ8WSeiwQ1lK5hwkCIqJ+amZOYPd778sbPha/S8Srw==",
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/reporters": "^26.4.1",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.6.1",
+            "@jest/reporters": "^26.6.1",
+            "@jest/test-result": "^26.6.1",
+            "@jest/transform": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
-            "jest-changed-files": "^26.3.0",
-            "jest-config": "^26.4.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-message-util": "^26.3.0",
+            "jest-changed-files": "^26.6.1",
+            "jest-config": "^26.6.1",
+            "jest-haste-map": "^26.6.1",
+            "jest-message-util": "^26.6.1",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-resolve-dependencies": "^26.4.2",
-            "jest-runner": "^26.4.2",
-            "jest-runtime": "^26.4.2",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
-            "jest-watcher": "^26.3.0",
+            "jest-resolve": "^26.6.1",
+            "jest-resolve-dependencies": "^26.6.1",
+            "jest-runner": "^26.6.1",
+            "jest-runtime": "^26.6.1",
+            "jest-snapshot": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jest-validate": "^26.6.1",
+            "jest-watcher": "^26.6.1",
             "micromatch": "^4.0.2",
             "p-each-series": "^2.1.0",
             "rimraf": "^3.0.0",
@@ -7956,11 +7924,10 @@
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
             },
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -8000,9 +7967,9 @@
               }
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -8015,49 +7982,49 @@
           }
         },
         "@jest/environment": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-          "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.1.tgz",
+          "integrity": "sha512-GNvHwkOFJtNgSwdzH9flUPzF9AYAZhUg124CBoQcwcZCM9s5TLz8Y3fMtiaWt4ffbigoetjGk5PU2Dd8nLrSEw==",
           "requires": {
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/fake-timers": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
-            "jest-mock": "^26.3.0"
+            "jest-mock": "^26.6.1"
           }
         },
         "@jest/fake-timers": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-          "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.6.1.tgz",
+          "integrity": "sha512-T/SkMLgOquenw/nIisBRD6XAYpFir0kNuclYLkse5BpzeDUukyBr+K31xgAo9M0hgjU9ORlekAYPSzc0DKfmKg==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "@sinonjs/fake-timers": "^6.0.1",
             "@types/node": "*",
-            "jest-message-util": "^26.3.0",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0"
+            "jest-message-util": "^26.6.1",
+            "jest-mock": "^26.6.1",
+            "jest-util": "^26.6.1"
           }
         },
         "@jest/globals": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-          "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.6.1.tgz",
+          "integrity": "sha512-acxXsSguuLV/CeMYmBseefw6apO7NuXqpE+v5r3yD9ye2PY7h1nS20vY7Obk2w6S7eJO4OIAJeDnoGcLC/McEQ==",
           "requires": {
-            "@jest/environment": "^26.3.0",
-            "@jest/types": "^26.3.0",
-            "expect": "^26.4.2"
+            "@jest/environment": "^26.6.1",
+            "@jest/types": "^26.6.1",
+            "expect": "^26.6.1"
           }
         },
         "@jest/reporters": {
-          "version": "26.4.1",
-          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-          "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.6.1.tgz",
+          "integrity": "sha512-J6OlXVFY3q1SXWJhjme5i7qT/BAZSikdOK2t8Ht5OS32BDo6KfG5CzIzzIFnAVd82/WWbc9Hb7SJ/jwSvVH9YA==",
           "requires": {
             "@bcoe/v8-coverage": "^0.2.3",
-            "@jest/console": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.6.1",
+            "@jest/test-result": "^26.6.1",
+            "@jest/transform": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "chalk": "^4.0.0",
             "collect-v8-coverage": "^1.0.0",
             "exit": "^0.1.2",
@@ -8068,24 +8035,23 @@
             "istanbul-lib-report": "^3.0.0",
             "istanbul-lib-source-maps": "^4.0.0",
             "istanbul-reports": "^3.0.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-resolve": "^26.4.0",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-haste-map": "^26.6.1",
+            "jest-resolve": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jest-worker": "^26.6.1",
             "node-notifier": "^8.0.0",
             "slash": "^3.0.0",
             "source-map": "^0.6.0",
             "string-length": "^4.0.1",
             "terminal-link": "^2.0.0",
-            "v8-to-istanbul": "^5.0.1"
+            "v8-to-istanbul": "^6.0.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -8122,9 +8088,9 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -8132,9 +8098,9 @@
           }
         },
         "@jest/source-map": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-          "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+          "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
           "requires": {
             "callsites": "^3.0.0",
             "graceful-fs": "^4.2.4",
@@ -8149,43 +8115,43 @@
           }
         },
         "@jest/test-result": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-          "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.1.tgz",
+          "integrity": "sha512-wqAgIerIN2gSdT2A8WeA5+AFh9XQBqYGf8etK143yng3qYd0mF0ie2W5PVmgnjw4VDU6ammI9NdXrKgNhreawg==",
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "collect-v8-coverage": "^1.0.0"
           }
         },
         "@jest/test-sequencer": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-          "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.6.1.tgz",
+          "integrity": "sha512-0csqA/XApZiNeTIPYh6koIDCACSoR6hi29T61tKJMtCZdEC+tF3PoNt7MS0oK/zKC6daBgCbqXxia5ztr/NyCQ==",
           "requires": {
-            "@jest/test-result": "^26.3.0",
+            "@jest/test-result": "^26.6.1",
             "graceful-fs": "^4.2.4",
-            "jest-haste-map": "^26.3.0",
-            "jest-runner": "^26.4.2",
-            "jest-runtime": "^26.4.2"
+            "jest-haste-map": "^26.6.1",
+            "jest-runner": "^26.6.1",
+            "jest-runtime": "^26.6.1"
           }
         },
         "@jest/transform": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-          "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.1.tgz",
+          "integrity": "sha512-oNFAqVtqRxZRx6vXL3I4bPKUK0BIlEeaalkwxyQGGI8oXDQBtYQBpiMe5F7qPs4QdvvFYB42gPGIMMcxXaBBxQ==",
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "babel-plugin-istanbul": "^6.0.0",
             "chalk": "^4.0.0",
             "convert-source-map": "^1.4.0",
             "fast-json-stable-stringify": "^2.0.0",
             "graceful-fs": "^4.2.4",
-            "jest-haste-map": "^26.3.0",
+            "jest-haste-map": "^26.6.1",
             "jest-regex-util": "^26.0.0",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.6.1",
             "micromatch": "^4.0.2",
             "pirates": "^4.0.1",
             "slash": "^3.0.0",
@@ -8194,11 +8160,10 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -8235,9 +8200,9 @@
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -8256,9 +8221,9 @@
           }
         },
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.1.tgz",
+          "integrity": "sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==",
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
@@ -8268,11 +8233,10 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -8304,9 +8268,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -8444,9 +8408,9 @@
           }
         },
         "@types/babel__core": {
-          "version": "7.1.9",
-          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-          "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+          "version": "7.1.10",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+          "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -8456,39 +8420,34 @@
           }
         },
         "@types/babel__generator": {
-          "version": "7.6.1",
-          "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-          "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+          "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
           "requires": {
             "@babel/types": "^7.0.0"
           }
         },
         "@types/babel__template": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-          "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+          "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0"
           }
         },
         "@types/babel__traverse": {
-          "version": "7.0.13",
-          "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-          "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+          "version": "7.0.15",
+          "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+          "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
           "requires": {
             "@babel/types": "^7.3.0"
           }
         },
-        "@types/color-name": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-        },
         "@types/graceful-fs": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
-          "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
+          "integrity": "sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==",
           "requires": {
             "@types/node": "*"
           }
@@ -8531,9 +8490,9 @@
           }
         },
         "@types/node": {
-          "version": "14.6.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-          "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+          "version": "14.14.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.3.tgz",
+          "integrity": "sha512-33/L34xS7HVUx23e0wOT2V1qPF1IrHgQccdJVm9uXGTB9vFBrrzBtkQymT8VskeKOxjz55MSqMv0xuLq+u98WQ=="
         },
         "@types/normalize-package-data": {
           "version": "2.4.0",
@@ -8546,14 +8505,14 @@
           "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
         },
         "@types/prettier": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
-          "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA=="
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+          "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ=="
         },
         "@types/stack-utils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-          "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
         },
         "@types/unist": {
           "version": "2.0.3",
@@ -8561,9 +8520,9 @@
           "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
         },
         "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "version": "15.0.9",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+          "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -8574,14 +8533,14 @@
           "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
         },
         "abab": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-          "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+          "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
         },
         "acorn": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
         },
         "acorn-globals": {
           "version": "6.0.0",
@@ -8611,9 +8570,9 @@
           }
         },
         "ajv": {
-          "version": "6.12.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -8761,26 +8720,25 @@
           "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
         },
         "babel-jest": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-          "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.1.tgz",
+          "integrity": "sha512-duMWEOKrSBYRVTTNpL2SipNIWnZOjP77auOBMPQ3zXAdnDbyZQWU8r/RxNWpUf9N6cgPFecQYelYLytTVXVDtA==",
           "requires": {
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/transform": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/babel__core": "^7.1.7",
             "babel-plugin-istanbul": "^6.0.0",
-            "babel-preset-jest": "^26.3.0",
+            "babel-preset-jest": "^26.5.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "slash": "^3.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -8812,9 +8770,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -8859,9 +8817,9 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "26.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-          "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+          "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
           "requires": {
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
@@ -8870,9 +8828,9 @@
           }
         },
         "babel-preset-current-node-syntax": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-          "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+          "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
           "requires": {
             "@babel/plugin-syntax-async-generators": "^7.8.4",
             "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -8888,11 +8846,11 @@
           }
         },
         "babel-preset-jest": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-          "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+          "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
           "requires": {
-            "babel-plugin-jest-hoist": "^26.2.0",
+            "babel-plugin-jest-hoist": "^26.5.0",
             "babel-preset-current-node-syntax": "^0.1.3"
           }
         },
@@ -9146,6 +9104,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
           "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        },
+        "cjs-module-lexer": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.4.3.tgz",
+          "integrity": "sha512-5RLK0Qfs0PNDpEyBXIr3bIT1Muw3ojSlvpw6dAmkUcO0+uTrsBn7GuEIgx40u+OzbCBLDta7nvmud85P4EmTsQ=="
         },
         "class-utils": {
           "version": "0.3.6",
@@ -9441,9 +9404,9 @@
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decimal.js": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-          "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+          "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
         },
         "decode-uri-component": {
           "version": "0.2.0",
@@ -9550,9 +9513,9 @@
           "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
         },
         "diff-sequences": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig=="
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q=="
         },
         "dir-glob": {
           "version": "3.0.1",
@@ -9614,9 +9577,9 @@
           "integrity": "sha512-q09qZdginlqDH3+Y1P6ch5UDTW8nZ1ijwMkxFs15J/DAWOwqolIx8HZH1UP0vReByBigk/dPlU22xS1MaZ+kpQ=="
         },
         "emittery": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
-          "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ=="
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
+          "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ=="
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -9817,24 +9780,23 @@
           }
         },
         "expect": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-          "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.1.tgz",
+          "integrity": "sha512-BRfxIBHagghMmr1D2MRY0Qv5d3Nc8HCqgbDwNXw/9izmM5eBb42a2YjLKSbsqle76ozGkAEPELQX4IdNHAKRNA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "ansi-styles": "^4.0.0",
             "jest-get-type": "^26.3.0",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
             "jest-regex-util": "^26.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -10357,6 +10319,14 @@
             "har-schema": "^2.0.0"
           }
         },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -10732,6 +10702,14 @@
             "ci-info": "^2.0.0"
           }
         },
+        "is-core-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+          "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -10965,9 +10943,9 @@
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11010,21 +10988,20 @@
           }
         },
         "jest": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-          "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.1.tgz",
+          "integrity": "sha512-f+ahfqw3Ffy+9vA7sWFGpTmhtKEMsNAZiWBVXDkrpIO73zIz22iimjirnV78kh/eWlylmvLh/0WxHN6fZraZdA==",
           "requires": {
-            "@jest/core": "^26.4.2",
+            "@jest/core": "^26.6.1",
             "import-local": "^3.0.2",
-            "jest-cli": "^26.4.2"
+            "jest-cli": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11056,29 +11033,29 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "jest-cli": {
-              "version": "26.4.2",
-              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-              "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+              "version": "26.6.1",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.1.tgz",
+              "integrity": "sha512-aPLoEjlwFrCWhiPpW5NUxQA1X1kWsAnQcQ0SO/fHsCvczL3W75iVAcH9kP6NN+BNqZcHNEvkhxT5cDmBfEAh+w==",
               "requires": {
-                "@jest/core": "^26.4.2",
-                "@jest/test-result": "^26.3.0",
-                "@jest/types": "^26.3.0",
+                "@jest/core": "^26.6.1",
+                "@jest/test-result": "^26.6.1",
+                "@jest/types": "^26.6.1",
                 "chalk": "^4.0.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.4",
                 "import-local": "^3.0.2",
                 "is-ci": "^2.0.0",
-                "jest-config": "^26.4.2",
-                "jest-util": "^26.3.0",
-                "jest-validate": "^26.4.2",
+                "jest-config": "^26.6.1",
+                "jest-util": "^26.6.1",
+                "jest-validate": "^26.6.1",
                 "prompts": "^2.0.1",
-                "yargs": "^15.3.1"
+                "yargs": "^15.4.1"
               }
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11086,11 +11063,11 @@
           }
         },
         "jest-changed-files": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-          "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.1.tgz",
+          "integrity": "sha512-NhSdZ5F6b/rIN5V46x1l31vrmukD/bJUXgYAY8VtP1SknYdJwjYDRxuLt7Z8QryIdqCjMIn2C0Cd98EZ4umo8Q==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "execa": "^4.0.0",
             "throat": "^5.0.0"
           },
@@ -11184,36 +11161,35 @@
           }
         },
         "jest-config": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-          "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.6.1.tgz",
+          "integrity": "sha512-mtJzIynIwW1d1nMlKCNCQiSgWaqFn8cH/fOSNY97xG7Y9tBCZbCSuW2GTX0RPmceSJGO7l27JgwC18LEg0Vg+g==",
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/test-sequencer": "^26.4.2",
-            "@jest/types": "^26.3.0",
-            "babel-jest": "^26.3.0",
+            "@jest/test-sequencer": "^26.6.1",
+            "@jest/types": "^26.6.1",
+            "babel-jest": "^26.6.1",
             "chalk": "^4.0.0",
             "deepmerge": "^4.2.2",
             "glob": "^7.1.1",
             "graceful-fs": "^4.2.4",
-            "jest-environment-jsdom": "^26.3.0",
-            "jest-environment-node": "^26.3.0",
+            "jest-environment-jsdom": "^26.6.1",
+            "jest-environment-node": "^26.6.1",
             "jest-get-type": "^26.3.0",
-            "jest-jasmine2": "^26.4.2",
+            "jest-jasmine2": "^26.6.1",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-resolve": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jest-validate": "^26.6.1",
             "micromatch": "^4.0.2",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11245,9 +11221,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11255,22 +11231,21 @@
           }
         },
         "jest-diff": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.1.tgz",
+          "integrity": "sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==",
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.3.0",
+            "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11302,9 +11277,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11320,23 +11295,22 @@
           }
         },
         "jest-each": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-          "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.6.1.tgz",
+          "integrity": "sha512-gSn8eB3buchuq45SU7pLB7qmCGax1ZSxfaWuEFblCyNMtyokYaKFh9dRhYPujK6xYL57dLIPhLKatjmB5XWzGA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "chalk": "^4.0.0",
             "jest-get-type": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "jest-util": "^26.6.1",
+            "pretty-format": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11368,9 +11342,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11378,30 +11352,30 @@
           }
         },
         "jest-environment-jsdom": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-          "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.6.1.tgz",
+          "integrity": "sha512-A17RiXuHYNVlkM+3QNcQ6n5EZyAc6eld8ra9TW26luounGWpku4tj03uqRgHJCI1d4uHr5rJiuCH5JFRtdmrcA==",
           "requires": {
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.6.1",
+            "@jest/fake-timers": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "jsdom": "^16.2.2"
+            "jest-mock": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jsdom": "^16.4.0"
           }
         },
         "jest-environment-node": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-          "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.1.tgz",
+          "integrity": "sha512-YffaCp6h0j1kbcf1NVZ7umC6CPgD67YS+G1BeornfuSkx5s3xdhuwG0DCxSiHPXyT81FfJzA1L7nXvhq50OWIg==",
           "requires": {
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.6.1",
+            "@jest/fake-timers": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0"
+            "jest-mock": "^26.6.1",
+            "jest-util": "^26.6.1"
           }
         },
         "jest-get-type": {
@@ -11410,11 +11384,11 @@
           "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
         },
         "jest-haste-map": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-          "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.1.tgz",
+          "integrity": "sha512-9kPafkv0nX6ta1PrshnkiyhhoQoFWncrU/uUBt3/AP1r78WSCU5iLceYRTwDvJl67H3RrXqSlSVDDa/AsUB7OQ==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "@types/graceful-fs": "^4.1.2",
             "@types/node": "*",
             "anymatch": "^3.0.3",
@@ -11422,45 +11396,44 @@
             "fsevents": "^2.1.2",
             "graceful-fs": "^4.2.4",
             "jest-regex-util": "^26.0.0",
-            "jest-serializer": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.6.1",
+            "jest-worker": "^26.6.1",
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
           }
         },
         "jest-jasmine2": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-          "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.6.1.tgz",
+          "integrity": "sha512-2uYdT32o/ZzSxYAPduAgokO8OlAL1YdG/9oxcEY138EDNpIK5XRRJDaGzTZdIBWSxk0aR8XxN44FvfXtHB+Fiw==",
           "requires": {
             "@babel/traverse": "^7.1.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/source-map": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.6.1",
+            "@jest/source-map": "^26.5.0",
+            "@jest/test-result": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "co": "^4.6.0",
-            "expect": "^26.4.2",
+            "expect": "^26.6.1",
             "is-generator-fn": "^2.0.0",
-            "jest-each": "^26.4.2",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-runtime": "^26.4.2",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "pretty-format": "^26.4.2",
+            "jest-each": "^26.6.1",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-runtime": "^26.6.1",
+            "jest-snapshot": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "pretty-format": "^26.6.1",
             "throat": "^5.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11492,9 +11465,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11502,31 +11475,30 @@
           }
         },
         "jest-leak-detector": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-          "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.1.tgz",
+          "integrity": "sha512-j9ZOtJSJKlHjrs4aIxWjiQUjyrffPdiAQn2Iw0916w7qZE5Lk0T2KhIH6E9vfhzP6sw0Q0jtnLLb4vQ71o1HlA==",
           "requires": {
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.6.1"
           }
         },
         "jest-matcher-utils": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz",
+          "integrity": "sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==",
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^26.4.2",
+            "jest-diff": "^26.6.1",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11558,9 +11530,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11568,13 +11540,13 @@
           }
         },
         "jest-message-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-          "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.1.tgz",
+          "integrity": "sha512-cqM4HnqncIebBNdTKrBoWR/4ufHTll0pK/FWwX0YasK+TlBQEMqw3IEdynuuOTjDPFO3ONlFn37280X48beByw==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@jest/types": "^26.3.0",
-            "@types/stack-utils": "^1.0.1",
+            "@jest/types": "^26.6.1",
+            "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.2",
@@ -11583,11 +11555,10 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11619,9 +11590,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11629,11 +11600,11 @@
           }
         },
         "jest-mock": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-          "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.1.tgz",
+          "integrity": "sha512-my0lPTBu1awY8iVG62sB2sx9qf8zxNDVX+5aFgoB8Vbqjb6LqIOsfyFA8P1z6H2IsqMbvOX9oCJnK67Y3yUIMA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "@types/node": "*"
           }
         },
@@ -11648,26 +11619,25 @@
           "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
         },
         "jest-resolve": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-          "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.6.1.tgz",
+          "integrity": "sha512-hiHfQH6rrcpAmw9xCQ0vD66SDuU+7ZulOuKwc4jpbmFFsz0bQG/Ib92K+9/489u5rVw0btr/ZhiHqBpmkbCvuQ==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "jest-pnp-resolver": "^1.2.2",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.6.1",
             "read-pkg-up": "^7.0.1",
-            "resolve": "^1.17.0",
+            "resolve": "^1.18.1",
             "slash": "^3.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11698,10 +11668,19 @@
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
+            "resolve": {
+              "version": "1.18.1",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+              "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+              "requires": {
+                "is-core-module": "^2.0.0",
+                "path-parse": "^1.0.6"
+              }
+            },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11709,48 +11688,47 @@
           }
         },
         "jest-resolve-dependencies": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-          "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.1.tgz",
+          "integrity": "sha512-MN6lufbZJ3RBfTnJesZtHu3hUCBqPdHRe2+FhIt0yiqJ3fMgzWRqMRQyN/d/QwOE7KXwAG2ekZutbPhuD7s51A==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "jest-regex-util": "^26.0.0",
-            "jest-snapshot": "^26.4.2"
+            "jest-snapshot": "^26.6.1"
           }
         },
         "jest-runner": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-          "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.1.tgz",
+          "integrity": "sha512-DmpNGdgsbl5s0FGkmsInmqnmqCtliCSnjWA2TFAJS1m1mL5atwfPsf+uoZ8uYQ2X0uDj4NM+nPcDnUpbNTRMBA==",
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.6.1",
+            "@jest/environment": "^26.6.1",
+            "@jest/test-result": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "emittery": "^0.7.1",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
-            "jest-config": "^26.4.2",
+            "jest-config": "^26.6.1",
             "jest-docblock": "^26.0.0",
-            "jest-haste-map": "^26.3.0",
-            "jest-leak-detector": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-resolve": "^26.4.0",
-            "jest-runtime": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-haste-map": "^26.6.1",
+            "jest-leak-detector": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-resolve": "^26.6.1",
+            "jest-runtime": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jest-worker": "^26.6.1",
             "source-map-support": "^0.5.6",
             "throat": "^5.0.0"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11782,9 +11760,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11792,44 +11770,44 @@
           }
         },
         "jest-runtime": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-          "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.1.tgz",
+          "integrity": "sha512-7uOCNeezXDWgjEyzYbRN2ViY7xNZzusNVGAMmU0UHRUNXuY4j4GBHKGMqPo/cBPZA9bSYp+lwK2DRRBU5Dv6YQ==",
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/globals": "^26.4.2",
-            "@jest/source-map": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.6.1",
+            "@jest/environment": "^26.6.1",
+            "@jest/fake-timers": "^26.6.1",
+            "@jest/globals": "^26.6.1",
+            "@jest/source-map": "^26.5.0",
+            "@jest/test-result": "^26.6.1",
+            "@jest/transform": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0",
+            "cjs-module-lexer": "^0.4.2",
             "collect-v8-coverage": "^1.0.0",
             "exit": "^0.1.2",
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.4",
-            "jest-config": "^26.4.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-message-util": "^26.3.0",
-            "jest-mock": "^26.3.0",
+            "jest-config": "^26.6.1",
+            "jest-haste-map": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-mock": "^26.6.1",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-resolve": "^26.6.1",
+            "jest-snapshot": "^26.6.1",
+            "jest-util": "^26.6.1",
+            "jest-validate": "^26.6.1",
             "slash": "^3.0.0",
             "strip-bom": "^4.0.0",
-            "yargs": "^15.3.1"
+            "yargs": "^15.4.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11861,9 +11839,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11871,42 +11849,42 @@
           }
         },
         "jest-serializer": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-          "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
           "requires": {
             "@types/node": "*",
             "graceful-fs": "^4.2.4"
           }
         },
         "jest-snapshot": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-          "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.1.tgz",
+          "integrity": "sha512-JA7bZp7HRTIJYAi85pJ/OZ2eur2dqmwIToA5/6d7Mn90isGEfeF9FvuhDLLEczgKP1ihreBzrJ6Vr7zteP5JNA==",
           "requires": {
             "@babel/types": "^7.0.0",
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
+            "@types/babel__traverse": "^7.0.4",
             "@types/prettier": "^2.0.0",
             "chalk": "^4.0.0",
-            "expect": "^26.4.2",
+            "expect": "^26.6.1",
             "graceful-fs": "^4.2.4",
-            "jest-diff": "^26.4.2",
+            "jest-diff": "^26.6.1",
             "jest-get-type": "^26.3.0",
-            "jest-haste-map": "^26.3.0",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-resolve": "^26.4.0",
+            "jest-haste-map": "^26.6.1",
+            "jest-matcher-utils": "^26.6.1",
+            "jest-message-util": "^26.6.1",
+            "jest-resolve": "^26.6.1",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^26.4.2",
+            "pretty-format": "^26.6.1",
             "semver": "^7.3.2"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -11943,9 +11921,9 @@
               "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -11953,11 +11931,11 @@
           }
         },
         "jest-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.1.tgz",
+          "integrity": "sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -11966,11 +11944,10 @@
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -12002,9 +11979,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -12012,31 +11989,30 @@
           }
         },
         "jest-validate": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-          "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.6.1.tgz",
+          "integrity": "sha512-BEFpGbylKocnNPZULcnk+TGaz1oFZQH/wcaXlaXABbu0zBwkOGczuWgdLucUouuQqn7VadHZZeTvo8VSFDLMOA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "camelcase": "^6.0.0",
             "chalk": "^4.0.0",
             "jest-get-type": "^26.3.0",
             "leven": "^3.1.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.6.1"
           },
           "dependencies": {
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
             "camelcase": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-              "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.1.0.tgz",
+              "integrity": "sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ=="
             },
             "chalk": {
               "version": "4.1.0",
@@ -12066,9 +12042,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -12076,16 +12052,16 @@
           }
         },
         "jest-watcher": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-          "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.1.tgz",
+          "integrity": "sha512-0LBIPPncNi9CaLKK15bnxyd2E8OMl4kJg0PTiNOI+MXztXw1zVdtX/x9Pr6pXaQYps+eS/ts43O4+HByZ7yJSw==",
           "requires": {
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/test-result": "^26.6.1",
+            "@jest/types": "^26.6.1",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.6.1",
             "string-length": "^4.0.1"
           },
           "dependencies": {
@@ -12098,11 +12074,10 @@
               }
             },
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -12134,9 +12109,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -12149,9 +12124,9 @@
           }
         },
         "jest-worker": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.1.tgz",
+          "integrity": "sha512-R5IE3qSGz+QynJx8y+ICEkdI2OJ3RJjRQVEyCcFAd3yVhQSEtquziPO29Mlzgn07LOVE8u8jhJ1FqcwegiXWOw==",
           "requires": {
             "@types/node": "*",
             "merge-stream": "^2.0.0",
@@ -12164,9 +12139,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -12238,9 +12213,9 @@
           "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
         },
         "json-parse-even-better-errors": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
-          "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json-schema": {
           "version": "0.2.3",
@@ -12435,6 +12410,11 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
           "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+        },
+        "marked": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.2.tgz",
+          "integrity": "sha512-5jjKHVl/FPo0Z6ocP3zYhKiJLzkwJAw4CZoLjv57FkvbUuwOX4LIBBGGcXjAY6ATcd1q9B8UTj5T9Umauj0QYQ=="
         },
         "mdast-squeeze-paragraphs": {
           "version": "4.0.0",
@@ -13032,14 +13012,14 @@
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "pretty-format": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "version": "26.6.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.1.tgz",
+          "integrity": "sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==",
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.6.1",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "react-is": "^17.0.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -13048,11 +13028,10 @@
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
             },
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },
@@ -13068,6 +13047,11 @@
               "version": "1.1.4",
               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            },
+            "react-is": {
+              "version": "17.0.1",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+              "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
             }
           }
         },
@@ -13090,12 +13074,12 @@
           "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
         },
         "prompts": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-          "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+          "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
           "requires": {
             "kleur": "^3.0.3",
-            "sisteransi": "^1.0.4"
+            "sisteransi": "^1.0.5"
           }
         },
         "prop-types": {
@@ -14119,9 +14103,9 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+          "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
         },
         "split-string": {
           "version": "3.1.0",
@@ -14322,9 +14306,9 @@
               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
             },
             "supports-color": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
               "requires": {
                 "has-flag": "^4.0.0"
               }
@@ -14776,9 +14760,9 @@
           }
         },
         "uri-js": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
           "requires": {
             "punycode": "^2.1.0"
           }
@@ -14812,15 +14796,15 @@
           "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
         },
         "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "optional": true
         },
         "v8-to-istanbul": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz",
-          "integrity": "sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-6.0.1.tgz",
+          "integrity": "sha512-PzM1WlqquhBvsV+Gco6WSFeg1AGdD53ccMRkFeyHRE/KRZaVacPOmQYP3EeVgDBtKD2BJ8kgynBQ5OtKiHCH+w==",
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.1",
             "convert-source-map": "^1.6.0",
@@ -14945,9 +14929,9 @@
           "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
         },
         "whatwg-url": {
-          "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.1.tgz",
-          "integrity": "sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+          "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^2.0.2",
@@ -14988,11 +14972,10 @@
               "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
             },
             "ansi-styles": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
               "requires": {
-                "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
               }
             },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "git+https://github.com/hashicorp/swingset.git"
   },
   "scripts": {
-    "example": "cd example && [ ! -d 'node_modules' ] && npm i || npm start",
+    "example": "cd examples/basic && [ ! -d 'node_modules' ] && npm i || npm start",
     "test": "jest",
     "release:major": "release major && npm publish",
     "release:minor": "release minor && npm publish",

--- a/style.module.css
+++ b/style.module.css
@@ -1,18 +1,3 @@
-.root {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
-    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  font-size: 16px;
-  line-height: 1.625;
-  text-rendering: optimizeLegibility;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-}
-
-.root * {
-  box-sizing: border-box;
-}
-
 .sidebar {
   background: #151b1d;
   color: white;
@@ -27,6 +12,19 @@
   display: flex;
   flex-direction: column;
   overflow: auto;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  font-size: 16px;
+  line-height: 1.625;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
+}
+
+.sidebar > * {
+  box-sizing: border-box;
 }
 
 .sidebar:before {
@@ -53,6 +51,7 @@
   padding: 10px 30px 10px 25px;
   display: block;
   color: white;
+  text-decoration: none;
 }
 
 .sidebar .logo {
@@ -74,7 +73,6 @@
   background-color: rgba(255, 255, 255, 0.1);
   color: white;
   border-radius: 4px;
-  width: 100%;
 }
 
 .sidebar .search:focus {
@@ -119,6 +117,13 @@
   margin-bottom: 1em;
   line-height: 1em;
   font-size: 2.2em;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.625;
+  text-rendering: optimizeLegibility;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
   color: #151b1d;
 }
 


### PR DESCRIPTION
Fixes https://app.asana.com/0/1100423001970639/1200120445315592

This is a bit messy of a fix, but I think it's important to let swingset consumers impose their own global styles so that the playground accurately represents the native environment where their components live, so hopefully this does the trick by only touching swingset UI elements.

Definitely makes the out-of-the-box styling a little uglier, but this doesn't really matter for our implementation, and we can revisit and spruce it up later if we plan to promote this publicly.