### PR TITLE
fix(deps): update peerDependency version range for next

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "next": "9.x",
+    "next": ">=9.x",
     "react": "16.x",
     "react-dom": "16.x",
     "webpack": "4.x",


### PR DESCRIPTION
Allows `next@10.x` to be used as peer dependency, this issue arose when moving to npm 7 for me

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/7191639/115735244-f00c1680-a34f-11eb-8066-087582351e4f.png">
