### PR TITLE
feat: support named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ With this in place, you should see your component's name render in the sidebar a
 Now let's actually make these docs useful. There are a few components that are made available within `docs.mdx` files that will help you to showcase your components.
 
 1. Your actual component. So in the example above, you can use `<Button />` right in that mdx file, and it will render an example however you please.
+1. Any components exposed as named exports from your component index file.
 1. Any components you list in the `peerComponents` frontmatter key.
    1. In the example above, `<ArrowIcon />` is added to scope.
    1. **Note:** `peerComponents` must also be present in Swingset (i.e., they must have a `docs.mdx` file). A warning will be emitted if any unknown components are passed here.

--- a/components-loader.js
+++ b/components-loader.js
@@ -121,7 +121,7 @@ function formatComponentsWithNames(components, config) {
 //     docsPath: '/absolute/path/to/component/docs.mdx',
 //     propsPath: '/absolute/path/to/component/props.js',
 //     slug: 'componentname',
-//     src: ComponentName,
+//     exports: ComponentNameExports,
 //     data: { componentName: 'ComponentName' }
 //   },
 //   ...
@@ -129,7 +129,7 @@ function formatComponentsWithNames(components, config) {
 // ```
 function generateMetadataFile(components, docsFiles) {
   const imports = components.reduce((memo, component) => {
-    memo += `import ${component.name} from '${component.path}'\n`
+    memo += `import * as ${component.name}Exports from '${component.path}'\n`
     return memo
   }, '')
 
@@ -141,7 +141,7 @@ function generateMetadataFile(components, docsFiles) {
       docsPath: '${path.join(component.path, 'docs.mdx')}',
       propsPath: '${path.join(component.path, 'props.js')}',
       slug: '${component.slug}',
-      src: ${component.name},
+      exports: ${component.name}Exports,
       data: ${JSON.stringify(component.data, null, 2)}
     },
   `

--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -6,7 +6,7 @@ This is the docs for the button component
 
 <LiveComponent components={{ Test: () => <p>test successful</p> }}>{`<>
   <Button text='this is a button' />
-  <ButtonSecondary text='this is another button' />
+  <ButtonSecondary text='${foo}' />
   <Test />
 </>`}</LiveComponent>
 

--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -6,6 +6,7 @@ This is the docs for the button component
 
 <LiveComponent components={{ Test: () => <p>test successful</p> }}>{`<>
   <Button text='this is a button' />
+  <ButtonSecondary text='this is another button' />
   <Test />
 </>`}</LiveComponent>
 

--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -6,7 +6,7 @@ This is the docs for the button component
 
 <LiveComponent components={{ Test: () => <p>test successful</p> }}>{`<>
   <Button text='this is a button' />
-  <ButtonSecondary text='${foo}' />
+  <ButtonSecondary text={\`\${foo}\`} />
   <Test />
 </>`}</LiveComponent>
 

--- a/examples/basic/components/button/index.jsx
+++ b/examples/basic/components/button/index.jsx
@@ -11,3 +11,5 @@ export default function Button({ text, testObject }) {
 export function ButtonSecondary({ text }) {
   return <button className={s.root}>{text}, secondary</button>
 }
+
+export const foo = 'bar'

--- a/examples/basic/components/button/index.jsx
+++ b/examples/basic/components/button/index.jsx
@@ -7,3 +7,7 @@ export default function Button({ text, testObject }) {
     </button>
   )
 }
+
+export function ButtonSecondary({ text }) {
+  return <button className={s.root}>{text}, secondary</button>
+}

--- a/page.jsx
+++ b/page.jsx
@@ -121,11 +121,15 @@ function ComponentPage({
   swingsetOptions,
   peerComponents,
 }) {
+  const { default: defaultExport, ...namedExports } = component.exports
   return (
     <MDXRemote
       {...mdxSource}
       components={createScope(
-        { [component.data.componentName]: component.src },
+        {
+          [component.data.componentName]: defaultExport,
+          ...namedExports,
+        },
         swingsetOptions,
         peerComponents
       )}

--- a/page.jsx
+++ b/page.jsx
@@ -133,6 +133,7 @@ function ComponentPage({
         swingsetOptions,
         peerComponents
       )}
+      scope={{ ...mdxSource.scope, ...namedExports }}
     />
   )
 }


### PR DESCRIPTION
Allow access to named exports from the component module, not just the default.
<img width="386" alt="Screen Shot 2021-06-15 at 4 28 07 PM" src="https://user-images.githubusercontent.com/1289701/122125937-acd19f80-cdf6-11eb-8bad-7721739a8c18.png">
