### PR TITLE
fix: update getPeerComponents to pull from the right spot

### DIFF
--- a/utils/get-peer-components.js
+++ b/utils/get-peer-components.js
@@ -4,15 +4,15 @@ export function getPeerComponents(entity, components) {
   if (!entity?.data?.peerComponents) return peerComponents
 
   entity.data.peerComponents.forEach((name) => {
-    const { src } = components[name]
-    if (!src) {
+    const component = components[name]
+    if (!component) {
       console.warn(
         `${
           entity.data.componentName ?? entity.data.name
         } lists ${name} as a peerComponent but <${name} /> is not in scope`
       )
     } else {
-      peerComponents[name] = src
+      peerComponents[name] = component.exports.default
     }
   })
 


### PR DESCRIPTION
Fixing up the peerComponents thing after our refactor of the components data structure.