### PR TITLE
feat: pass components to DocsPage

### DIFF
--- a/page.jsx
+++ b/page.jsx
@@ -90,7 +90,11 @@ export default function createPage(swingsetOptions = {}) {
           {sourceType === 'index' ? (
             swingsetOptions.index ?? <IndexPage />
           ) : sourceType === 'docs' ? (
-            <DocsPage mdxSource={mdxSource} peerComponents={peerComponents} />
+            <DocsPage
+              mdxSource={mdxSource}
+              peerComponents={peerComponents}
+              swingsetOptions={swingsetOptions}
+            />
           ) : sourceType === 'components' ? (
             <ComponentPage
               mdxSource={mdxSource}
@@ -111,8 +115,13 @@ function IndexPage() {
   return <h1>Welcome to Swingset!</h1>
 }
 
-function DocsPage({ mdxSource, peerComponents }) {
-  return <MDXRemote {...mdxSource} components={peerComponents} />
+function DocsPage({ mdxSource, peerComponents, swingsetOptions }) {
+  return (
+    <MDXRemote
+      {...mdxSource}
+      components={createScope({}, swingsetOptions, peerComponents)}
+    />
+  )
 }
 
 function ComponentPage({


### PR DESCRIPTION
Ensures that any components passed through as options are also passed through to `DocsPage`. So when we call:
```ts
createPage({ components: { ... } })
```

Any docs pages declared in the `docsRoot` will get access to these components.