### PR TITLE
Windows compatibility

### DIFF
--- a/components-loader.js
+++ b/components-loader.js
@@ -55,7 +55,7 @@ function removeComponentsWithoutDocs(components, pluginOptions, config) {
 // Add the component folder as a dependency so webpack knows when to reload
 function addWebpackDependencies(components) {
   components.map((componentDir) => {
-    this.addContextDependency(componentDir)
+    this.addContextDependency(path.resolve(componentDir))
   })
 }
 
@@ -138,8 +138,8 @@ function generateMetadataFile(components, docsFiles) {
     // src: Button, <<< Button NOT in quotes
     acc += `  '${component.name}': {
       path: '${component.path}',
-      docsPath: '${path.join(component.path, 'docs.mdx')}',
-      propsPath: '${path.join(component.path, 'props.js')}',
+      docsPath: '${path.join(component.path, 'docs.mdx').replace(/\\/g, '/')}',
+      propsPath: '${path.join(component.path, 'props.js').replace(/\\/g, '/')}',
       slug: '${component.slug}',
       exports: ${component.name}Exports,
       data: ${JSON.stringify(component.data, null, 2)}

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ module.exports =
           pluginOptions.componentsRoot
             ? pluginOptions.componentsRoot
             : 'components/*'
-        )
+        ).replace(/\\/g, '/')
         // normalize docsRoot path
         pluginOptions.docsRoot = path.resolve(
           config.context,
           pluginOptions.docsRoot ? pluginOptions.docsRoot : 'docs/*'
-        )
+        ).replace(/\\/g, '/')
         //
         config.module.rules.push({
           test: /__swingset_data/,


### PR DESCRIPTION
Hello,

on Windows swingset cannot find any component or doc. 
Root cause is that globby / fast-glob cannot resolve paths with backslashes (see https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows). 
This PR changes `addSwingset` in `index.js` to replace backslashes and changes `component-loader.js` to replace backslashes again after `path.join` calls. 

In` component-loader.js` `addWebpackDependencies` the path is resolved back to OS style, as `addContextDependency` requires path with backslashes.

Best Regards,
Frank
