### PR TITLE
Prop assignment based on Props.ts

### DIFF
--- a/components-loader.js
+++ b/components-loader.js
@@ -134,12 +134,20 @@ function generateMetadataFile(components, docsFiles) {
   }, '')
 
   const componentsData = components.reduce((acc, component) => {
+    const hasTypescriptProps = fs.existsSync(
+      path.join(component.path, 'props.ts')
+    )
+
     // We can't just stringify here, because we need eg
     // src: Button, <<< Button NOT in quotes
     acc += `  '${component.name}': {
       path: '${component.path}',
       docsPath: '${path.join(component.path, 'docs.mdx')}',
-      propsPath: '${path.join(component.path, 'props.js')}',
+      propsPath: '${
+        hasTypescriptProps
+          ? path.join(component.path, 'props.ts')
+          : path.join(component.path, 'props.js')
+      }',
       slug: '${component.slug}',
       exports: ${component.name}Exports,
       data: ${JSON.stringify(component.data, null, 2)}

--- a/examples/basic/components/button/props.ts
+++ b/examples/basic/components/button/props.ts
@@ -1,34 +1,28 @@
-module.exports = {
+export default {
   text: {
     control: 'text',
-    type: 'string',
     defaultValue: 'button text',
     description: 'the text displayed by the button',
   },
   testObject: {
-    type: 'object',
     description: 'test description yay',
     properties: {
       foo: {
-        type: 'object',
         description: 'test description',
         properties: {
           bar: {
-            type: 'string',
             description: 'deep nested yeahh',
           },
         },
       },
       baz: {
-        type: 'array',
         description: 'a test array, nice',
         properties: [
-          { type: 'string', description: 'any string value' },
+          { description: 'any string value' },
           {
-            type: 'object',
             description: 'an object value',
             properties: {
-              quux: { type: 'string', description: 'object in an array' },
+              quux: { description: 'object in an array' },
             },
           },
         ],
@@ -36,13 +30,20 @@ module.exports = {
     },
   },
   testObj2: {
-    type: 'array',
     description: 'test obj with monotype array',
     properties: [
       {
-        type: 'string',
         description: 'only a string is allowed',
       },
     ],
   },
+}
+
+export interface Props {
+  testObj2: string[]
+  testObject: {
+    foo: {
+      bar: string
+    }
+  }
 }

--- a/examples/basic/components/link/docs.mdx
+++ b/examples/basic/components/link/docs.mdx
@@ -9,13 +9,4 @@ This is the docs for the Link component
   {`<Link href="https://hashicorp.com" text='this is a link' />`}
 </LiveComponent>
 
-<PropsTable
-  props={{
-    text: { type: 'string', description: 'link text', required: true },
-    href: {
-      type: 'string',
-      description: 'link href',
-      required: true,
-    },
-  }}
-/>
+<PropsTable props={componentProps} />

--- a/examples/basic/components/link/index.tsx
+++ b/examples/basic/components/link/index.tsx
@@ -1,6 +1,11 @@
 import s from './style.module.css'
 
-export default function Link({ text, href }: { text: string; href: string }) {
+export interface Props {
+  text: string
+  href: string
+}
+
+export default function Link({ text, href }: Props) {
   return (
     <a className={s.root} href={href}>
       {text}

--- a/examples/basic/components/link/props.ts
+++ b/examples/basic/components/link/props.ts
@@ -1,0 +1,8 @@
+export default {
+  text: { description: 'link text' },
+  href: {
+    description: 'link href',
+  },
+}
+
+export type { Props } from './index'

--- a/examples/basic/yalc.lock
+++ b/examples/basic/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "swingset": {
-      "signature": "bf65767774a59436f5409505dbb4641c",
+      "signature": "4b219090d31d4ec60f5a4370223da035",
       "file": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
+        "@structured-types/api": "^3.46.11",
         "classnames": "^2.3.1",
         "copy-text-to-clipboard": "^2.2.0",
         "fsexists": "^1.0.1",
@@ -1484,6 +1485,31 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@structured-types/api": {
+      "version": "3.46.11",
+      "resolved": "https://registry.npmjs.org/@structured-types/api/-/api-3.46.11.tgz",
+      "integrity": "sha512-A8CFJbdNWuuyyHkr/KcRchGzp1V49D5OagWwmTr4+Tx4nt+/N3Efb8anZuZIYux4ACEAEx6MwSOWdoOglwkutg==",
+      "dependencies": {
+        "@structured-types/typescript-config": "^3.46.9",
+        "deepmerge": "^4.2.2",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.2.0"
+      }
+    },
+    "node_modules/@structured-types/typescript-config": {
+      "version": "3.46.9",
+      "resolved": "https://registry.npmjs.org/@structured-types/typescript-config/-/typescript-config-3.46.9.tgz",
+      "integrity": "sha512-hZhrNmywgX0VqeHi6gT7fFSJ1cCBW3iXPTQE4HpABm7VU4MHBwyFETGFTvFKdx8ARC+qK942rysP4NAE/NDcdg==",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^4.0.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2635,7 +2661,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7530,6 +7555,11 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8864,7 +8894,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10607,6 +10636,25 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@structured-types/api": {
+      "version": "3.46.11",
+      "resolved": "https://registry.npmjs.org/@structured-types/api/-/api-3.46.11.tgz",
+      "integrity": "sha512-A8CFJbdNWuuyyHkr/KcRchGzp1V49D5OagWwmTr4+Tx4nt+/N3Efb8anZuZIYux4ACEAEx6MwSOWdoOglwkutg==",
+      "requires": {
+        "@structured-types/typescript-config": "^3.46.9",
+        "deepmerge": "^4.2.2",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "@structured-types/typescript-config": {
+      "version": "3.46.9",
+      "resolved": "https://registry.npmjs.org/@structured-types/typescript-config/-/typescript-config-3.46.9.tgz",
+      "integrity": "sha512-hZhrNmywgX0VqeHi6gT7fFSJ1cCBW3iXPTQE4HpABm7VU4MHBwyFETGFTvFKdx8ARC+qK942rysP4NAE/NDcdg==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "path-browserify": "^1.0.1"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -11548,8 +11596,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "defaults": {
       "version": "1.0.3",
@@ -15078,6 +15125,11 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -16072,8 +16124,7 @@
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "unified": {
       "version": "10.1.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/hashicorp/swingset/issues"
   },
   "dependencies": {
+    "@structured-types/api": "^3.46.11",
     "classnames": "^2.3.1",
     "copy-text-to-clipboard": "^2.2.0",
     "fsexists": "^1.0.1",

--- a/utils/props.ts
+++ b/utils/props.ts
@@ -1,0 +1,145 @@
+import {
+  ArrayProp,
+  hasValue,
+  isArrayProp,
+  isObjectProp,
+  ObjectProp,
+  PropKind,
+  PropType,
+} from '@structured-types/api'
+
+function getTypeFromKind(kind?: PropKind) {
+  if (!kind) return PropKind[PropKind.Unknown]
+
+  if (kind === PropKind.Type) return PropKind[PropKind.Object]
+
+  return PropKind[kind]
+}
+
+function getTypeFromProperties(prop: ObjectProp | ArrayProp) {
+  const propertiesProp: ObjectProp | ArrayProp | undefined =
+    prop.properties?.find((p) => p.name === 'properties')
+
+  if (propertiesProp) {
+    if ('properties' in propertiesProp) {
+      return {
+        ...getValues(prop),
+        type: getTypeFromKind(propertiesProp.kind),
+        properties: getValues(propertiesProp),
+      }
+    }
+    return {
+      ...getValues(prop),
+      type: getTypeFromKind(propertiesProp.kind),
+    }
+  }
+
+  return getValues(prop)
+}
+
+function getValues(prop: ObjectProp | ArrayProp): Record<string, any> | null {
+  if (!prop) return null
+
+  if (!prop.properties?.length) {
+    return null
+  }
+
+  return prop.properties?.reduce((acc, property) => {
+    if (!property.name) return acc
+
+    if (isObjectProp(property)) {
+      acc[property.name] = getTypeFromProperties(property)
+      return acc
+    }
+
+    if (isArrayProp(property) && property.value) {
+      acc[property.name] = property.value.map((prop) =>
+        getTypeFromProperties(prop)
+      )
+
+      return acc
+    }
+
+    if (!hasValue(property)) return acc
+
+    return {
+      ...acc,
+      [property.name]: property.value,
+      type: property.type
+        ? property.type
+        : property.name === 'defaultValue'
+        ? getTypeFromKind(property.kind)
+        : null,
+    }
+  }, {} as Record<string, any>)
+}
+
+export function populateComponentPropsFromInterface(
+  object: Record<string, PropType>,
+  props: PropType[]
+) {
+  for (let property in object) {
+    const iface = props.find((prop) => prop.name === property)
+
+    if (iface) {
+      object[property].type = getTypeFromKind(iface?.kind)
+      if (!iface.optional) {
+        // @ts-ignore
+        object[property].required = true
+      }
+
+      // @ts-ignore
+      if (object[property].properties && 'properties' in iface) {
+        populateComponentPropsFromInterface(
+          // @ts-ignore
+          object[property].properties!,
+          // @ts-ignore
+          iface.properties ?? []
+        )
+      }
+    } else {
+      const propsWithNestedProperties: ObjectProp[] | ArrayProp[] =
+        props.filter((p) => 'properties' in p)
+
+      if (propsWithNestedProperties.length) {
+        for (let i = 0; i < propsWithNestedProperties.length; i++) {
+          populateComponentPropsFromInterface(
+            // @ts-ignore
+            object[property].properties!,
+            propsWithNestedProperties[i].properties ?? []
+          )
+        }
+      } else {
+        object[property].type = getTypeFromKind(props[0].kind)
+      }
+    }
+  }
+}
+
+export function populateComponentPropsFromDefaultValues(
+  acc: Record<string, any>,
+  rootKeys: PropType[]
+) {
+  rootKeys.forEach((root) => {
+    if (!root.name || !isObjectProp(root)) return
+
+    if (root.properties?.some((prop) => prop.name === 'properties')) {
+      acc[root.name] = getTypeFromProperties(root)
+
+      populateComponentPropsFromDefaultValues(acc[root.name], root.properties)
+    } else if (isObjectProp(root) || isArrayProp(root)) {
+      acc[root.name] = getValues(root)
+      const defaultValue = root.properties?.find(
+        (prop) => prop.name === 'defaultValue'
+      )
+
+      if (defaultValue) {
+        acc[root.name].type = getTypeFromKind(defaultValue.kind)
+      }
+
+      if (root.type) {
+        acc[root.name].type = root.type
+      }
+    }
+  })
+}


### PR DESCRIPTION
- Props.ts can now be used rather than Props.js for assigning props to a component (see: examples/basic/link & examples/basic/button)
- If a defaultValue is specified for a prop, it will attempt to infer the type based on that. 
- Props.js will still work as before

TODO: Some API cleanup & remove some ts-ignores 