### PR TITLE
feat: ignore node_modules folders when resolving components glob

### DIFF
--- a/.changeset/itchy-bats-exist.md
+++ b/.changeset/itchy-bats-exist.md
@@ -1,0 +1,5 @@
+---
+'swingset': minor
+---
+
+Ignore node_modules folders when resolving components glob

--- a/components-loader.js
+++ b/components-loader.js
@@ -10,9 +10,13 @@ module.exports = function swingsetComponentsLoader() {
   const { pluginOptions, webpackConfig } = getOptions(this)
 
   // Resolve components glob
-  const allComponents = globby.sync(`${pluginOptions.componentsRoot}`, {
-    onlyFiles: false,
-  })
+  const allComponents = globby
+    .sync(`${pluginOptions.componentsRoot}`, {
+      onlyFiles: false,
+    })
+    .filter((folderPath) => {
+      return !folderPath.includes('node_modules')
+    })
 
   const usedComponents = removeComponentsWithoutDocs(
     allComponents,


### PR DESCRIPTION
This PR ignores `node_modules` folders when resolving the components glob, which allows for nested components in a single package.