### PR TITLE
Enable fullscreen content area in `swingset`

### DIFF
--- a/.changeset/cyan-years-retire.md
+++ b/.changeset/cyan-years-retire.md
@@ -1,0 +1,5 @@
+---
+'swingset': minor
+---
+
+Adding fullscreen button

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
+        "@reach/visually-hidden": "^0.17.0",
         "classnames": "^2.3.1",
         "copy-text-to-clipboard": "^2.2.0",
         "fsexists": "^1.0.1",
@@ -1944,6 +1945,19 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@reach/visually-hidden": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -9222,6 +9236,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/property-information": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
@@ -9343,6 +9367,11 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-live": {
       "version": "3.0.0",
@@ -13263,6 +13292,15 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "@reach/visually-hidden": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "tslib": "^2.3.0"
       }
     },
     "@sinonjs/commons": {
@@ -18641,6 +18679,16 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "property-information": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
@@ -18720,6 +18768,11 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-live": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "swingset",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swingset",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@reach/visually-hidden": "^0.17.0",
+        "@reach/visually-hidden": "^0.18.0",
         "classnames": "^2.3.1",
         "copy-text-to-clipboard": "^2.2.0",
         "fsexists": "^1.0.1",
@@ -1948,16 +1948,23 @@
       }
     },
     "node_modules/@reach/visually-hidden": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
-      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.18.0.tgz",
+      "integrity": "sha512-NsJ3oeHJtPc6UOeV6MHMuzQ5sl1ouKhW85i3C0S7VM+klxVlYScBZ2J4UVnWB50A2c+evdVpCnld2YeuyYYwBw==",
       "dependencies": {
-        "prop-types": "^15.7.2",
-        "tslib": "^2.3.0"
+        "@reach/polymorphic": "0.18.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
+      }
+    },
+    "node_modules/@reach/visually-hidden/node_modules/@reach/polymorphic": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/polymorphic/-/polymorphic-0.18.0.tgz",
+      "integrity": "sha512-N9iAjdMbE//6rryZZxAPLRorzDcGBnluf7YQij6XDLiMtfCj1noa7KyLpEc/5XCIB/EwhX3zCluFAwloBKdblA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -9236,16 +9243,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/property-information": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
@@ -9367,11 +9364,6 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-live": {
       "version": "3.0.0",
@@ -13295,12 +13287,19 @@
       }
     },
     "@reach/visually-hidden": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
-      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.18.0.tgz",
+      "integrity": "sha512-NsJ3oeHJtPc6UOeV6MHMuzQ5sl1ouKhW85i3C0S7VM+klxVlYScBZ2J4UVnWB50A2c+evdVpCnld2YeuyYYwBw==",
       "requires": {
-        "prop-types": "^15.7.2",
-        "tslib": "^2.3.0"
+        "@reach/polymorphic": "0.18.0"
+      },
+      "dependencies": {
+        "@reach/polymorphic": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/@reach/polymorphic/-/polymorphic-0.18.0.tgz",
+          "integrity": "sha512-N9iAjdMbE//6rryZZxAPLRorzDcGBnluf7YQij6XDLiMtfCj1noa7KyLpEc/5XCIB/EwhX3zCluFAwloBKdblA==",
+          "requires": {}
+        }
       }
     },
     "@sinonjs/commons": {
@@ -18679,16 +18678,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "property-information": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
@@ -18768,11 +18757,6 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-live": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/hashicorp/swingset/issues"
   },
   "dependencies": {
-    "@reach/visually-hidden": "^0.17.0",
+    "@reach/visually-hidden": "^0.18.0",
     "classnames": "^2.3.1",
     "copy-text-to-clipboard": "^2.2.0",
     "fsexists": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/hashicorp/swingset/issues"
   },
   "dependencies": {
+    "@reach/visually-hidden": "^0.17.0",
     "classnames": "^2.3.1",
     "copy-text-to-clipboard": "^2.2.0",
     "fsexists": "^1.0.1",

--- a/page.tsx
+++ b/page.tsx
@@ -25,6 +25,12 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
       setIsFullscreen(!isFullscreen);
     }
 
+    useEffect(() => {
+      if (router.query.isFullscreen) {
+        setIsFullscreen(true)
+      }
+    }, [router.query.isFullscreen])
+
     // Focus the search input when pressing the '/' key
     useEffect(() => {
       function onKeyDown(e: KeyboardEvent) {

--- a/page.tsx
+++ b/page.tsx
@@ -23,9 +23,15 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const searchInputRef = useRef<HTMLInputElement>(null)
     const isFullscreen = router?.query?.isFullscreen && router?.query?.isFullscreen === 'true'
     const handleFullscreenBttnClick = () => {
-      router.replace({
-        query: { ...router.query, isFullscreen: !isFullscreen }
-      })
+      router.replace(
+        {
+          query: { ...router.query, isFullscreen: !isFullscreen}
+        },
+        undefined,
+        {
+          shallow: true,
+        }
+      )
     }
 
     // Focus the search input when pressing the '/' key

--- a/page.tsx
+++ b/page.tsx
@@ -19,6 +19,10 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const baseRoute = useBaseRoute()
     const [filterValue, setFilterValue] = useState<string | undefined>()
     const searchInputRef = useRef<HTMLInputElement>(null)
+    const [isFullscreen, setIsFullscreen] = useState(false)
+    const handleFullscreenBttnClick = () => {
+      setIsFullscreen(!isFullscreen);
+    }
 
     // Focus the search input when pressing the '/' key
     useEffect(() => {
@@ -89,6 +93,9 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
           <Nav navData={filteredNav} />
         </div>
         <div className={s.stage}>
+          <div className={s.fullscreenBttn} onClick={handleFullscreenBttnClick}>
+            { isFullscreen ? (<CloseFullscreenIcon />) :  (<FullscreenIcon />)}
+          </div>
           {sourceType === 'index' ? (
             swingsetOptions.index ?? <IndexPage />
           ) : sourceType === 'docs' ? (
@@ -111,6 +118,18 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
       </div>
     )
   }
+}
+
+const FullscreenIcon = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M5 19v-5h2v3h3v2Zm0-9V5h5v2H7v3Zm9 9v-2h3v-3h2v5Zm3-9V7h-3V5h5v5Z"></path></svg>
+  )
+}
+
+const CloseFullscreenIcon = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M3.4 22 2 20.6 8.6 14H4v-2h8v8h-2v-4.6ZM12 12V4h2v4.6L20.6 2 22 3.4 15.4 10H20v2Z"/></svg>
+  )
 }
 
 function IndexPage() {

--- a/page.tsx
+++ b/page.tsx
@@ -23,12 +23,16 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const searchInputRef = useRef<HTMLInputElement>(null)
     const [isFullscreen, setIsFullscreen] = useState(false)
     const handleFullscreenBttnClick = () => {
-      setIsFullscreen(!isFullscreen);
+      router.replace({
+        query: { ...router.query, isFullscreen: !isFullscreen }
+      })
     }
 
     useEffect(() => {
-      if (router.query.isFullscreen === 'true') {
+      if (router.query.isFullscreen && router.query.isFullscreen === 'true') {
         setIsFullscreen(true)
+      } else {
+        setIsFullscreen(false)
       }
     }, [router.query.isFullscreen])
 

--- a/page.tsx
+++ b/page.tsx
@@ -21,20 +21,12 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const baseRoute = useBaseRoute()
     const [filterValue, setFilterValue] = useState<string | undefined>()
     const searchInputRef = useRef<HTMLInputElement>(null)
-    const [isFullscreen, setIsFullscreen] = useState(false)
+    const isFullscreen = router?.query?.isFullscreen && router?.query?.isFullscreen === 'true'
     const handleFullscreenBttnClick = () => {
       router.replace({
         query: { ...router.query, isFullscreen: !isFullscreen }
       })
     }
-
-    useEffect(() => {
-      if (router.query.isFullscreen && router.query.isFullscreen === 'true') {
-        setIsFullscreen(true)
-      } else {
-        setIsFullscreen(false)
-      }
-    }, [router.query.isFullscreen])
 
     // Focus the search input when pressing the '/' key
     useEffect(() => {

--- a/page.tsx
+++ b/page.tsx
@@ -129,7 +129,7 @@ const FullscreenIcon = () => {
 
 const CloseFullscreenIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M3.4 22 2 20.6 8.6 14H4v-2h8v8h-2v-4.6ZM12 12V4h2v4.6L20.6 2 22 3.4 15.4 10H20v2Z"/></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M8 19v-3H5v-2h5v5Zm6 0v-5h5v2h-3v3Zm-9-9V8h3V5h2v5Zm9 0V5h2v3h3v2Z"/></svg>
   )
 }
 

--- a/page.tsx
+++ b/page.tsx
@@ -12,6 +12,7 @@ import { useBaseRoute } from './utils/use-base-route'
 import Nav from './components/nav'
 import { ComponentData, SwingsetPageProps, SwingsetOptions } from './types'
 import classNames from 'classnames'
+import VisuallyHidden from '@reach/visually-hidden'
 
 export default function createPage(swingsetOptions: SwingsetOptions = {}) {
   return function Page({ sourceType, mdxSource, navData }: SwingsetPageProps) {
@@ -100,9 +101,9 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
           <Nav navData={filteredNav} />
         </div>
         <div className={classNames(s.stage, { [s.isFullscreen]: isFullscreen})}>
-          <button className={s.fullscreenBttn} aria-labelledby="buttonLabel" onClick={handleFullscreenBttnClick}>
+          <button className={s.fullscreenBttn} onClick={handleFullscreenBttnClick}>
             { isFullscreen ? (<CloseFullscreenIcon />) : (<FullscreenIcon />)}
-            <span id="buttonLabel" hidden>{ isFullscreen ? 'Close fullscreen' : 'Enter fullscreen'}</span>    
+            <VisuallyHidden>{ isFullscreen ? 'Close fullscreen' : 'Enter fullscreen'}</VisuallyHidden>    
           </button>
           {sourceType === 'index' ? (
             swingsetOptions.index ?? <IndexPage />

--- a/page.tsx
+++ b/page.tsx
@@ -124,13 +124,13 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
 
 const FullscreenIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M5 19v-5h2v3h3v2Zm0-9V5h5v2H7v3Zm9 9v-2h3v-3h2v5Zm3-9V7h-3V5h5v5Z"></path></svg>
+    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M5 19v-5h2v3h3v2Zm0-9V5h5v2H7v3Zm9 9v-2h3v-3h2v5Zm3-9V7h-3V5h5v5Z"></path></svg>
   )
 }
 
 const CloseFullscreenIcon = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M8 19v-3H5v-2h5v5Zm6 0v-5h5v2h-3v3Zm-9-9V8h3V5h2v5Zm9 0V5h2v3h3v2Z"/></svg>
+    <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" height="24" width="24"><path d="M8 19v-3H5v-2h5v5Zm6 0v-5h5v2h-3v3Zm-9-9V8h3V5h2v5Zm9 0V5h2v3h3v2Z"/></svg>
   )
 }
 

--- a/page.tsx
+++ b/page.tsx
@@ -11,6 +11,7 @@ import { getPeerComponents } from './utils/get-peer-components'
 import { useBaseRoute } from './utils/use-base-route'
 import Nav from './components/nav'
 import { ComponentData, SwingsetPageProps, SwingsetOptions } from './types'
+import classNames from 'classnames'
 
 export default function createPage(swingsetOptions: SwingsetOptions = {}) {
   return function Page({ sourceType, mdxSource, navData }: SwingsetPageProps) {
@@ -74,7 +75,7 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
         <Head>
           <title key="title">Component Library</title>
         </Head>
-        <div className={s.sidebar}>
+        <div className={classNames(s.sidebar, { [s.isFullscreen]: isFullscreen})}>
           <Link href={baseRoute || '/'} legacyBehavior>
             <a>{swingsetOptions.logo ?? <span className={s.logo} />}</a>
           </Link>
@@ -92,7 +93,7 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
           </div>
           <Nav navData={filteredNav} />
         </div>
-        <div className={s.stage}>
+        <div className={classNames(s.stage, { [s.isFullscreen]: isFullscreen})}>
           <div className={s.fullscreenBttn} onClick={handleFullscreenBttnClick}>
             { isFullscreen ? (<CloseFullscreenIcon />) :  (<FullscreenIcon />)}
           </div>

--- a/page.tsx
+++ b/page.tsx
@@ -94,9 +94,10 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
           <Nav navData={filteredNav} />
         </div>
         <div className={classNames(s.stage, { [s.isFullscreen]: isFullscreen})}>
-          <div className={s.fullscreenBttn} onClick={handleFullscreenBttnClick}>
-            { isFullscreen ? (<CloseFullscreenIcon />) :  (<FullscreenIcon />)}
-          </div>
+          <button className={s.fullscreenBttn} aria-labelledby="buttonLabel" onClick={handleFullscreenBttnClick}>
+            { isFullscreen ? (<CloseFullscreenIcon />) : (<FullscreenIcon />)}
+            <span id="buttonLabel" hidden>{ isFullscreen ? 'Close fullscreen' : 'Enter fullscreen'}</span>    
+          </button>
           {sourceType === 'index' ? (
             swingsetOptions.index ?? <IndexPage />
           ) : sourceType === 'docs' ? (

--- a/page.tsx
+++ b/page.tsx
@@ -23,9 +23,7 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const searchInputRef = useRef<HTMLInputElement>(null)
     const [isFullscreen, setIsFullscreen] = useState(false)
     const handleFullscreenBttnClick = () => {
-      router.push({
-        query: { isFullscreen: !isFullscreen }
-      })
+      setIsFullscreen(!isFullscreen);
     }
 
     useEffect(() => {

--- a/page.tsx
+++ b/page.tsx
@@ -23,7 +23,9 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     const searchInputRef = useRef<HTMLInputElement>(null)
     const [isFullscreen, setIsFullscreen] = useState(false)
     const handleFullscreenBttnClick = () => {
-      setIsFullscreen(!isFullscreen);
+      router.push({
+        query: { isFullscreen: !isFullscreen }
+      })
     }
 
     useEffect(() => {

--- a/page.tsx
+++ b/page.tsx
@@ -12,7 +12,7 @@ import { useBaseRoute } from './utils/use-base-route'
 import Nav from './components/nav'
 import { ComponentData, SwingsetPageProps, SwingsetOptions } from './types'
 import classNames from 'classnames'
-import VisuallyHidden from '@reach/visually-hidden'
+import { VisuallyHidden } from '@reach/visually-hidden'
 
 export default function createPage(swingsetOptions: SwingsetOptions = {}) {
   return function Page({ sourceType, mdxSource, navData }: SwingsetPageProps) {

--- a/page.tsx
+++ b/page.tsx
@@ -26,7 +26,7 @@ export default function createPage(swingsetOptions: SwingsetOptions = {}) {
     }
 
     useEffect(() => {
-      if (router.query.isFullscreen) {
+      if (router.query.isFullscreen === 'true') {
         setIsFullscreen(true)
       }
     }, [router.query.isFullscreen])

--- a/style.module.css
+++ b/style.module.css
@@ -126,7 +126,7 @@
   justify-content: center;
   align-items: center;
   padding: 0;
-  backround-color: transparent;
+  background-color: transparent;
 }
 
 .stage > :global(.__swingset-headline) {

--- a/style.module.css
+++ b/style.module.css
@@ -104,6 +104,7 @@
 }
 
 .stage {
+  position: relative;
   padding: 20px 30px 30px;
   margin-left: 270px;
   transition: margin-left .5s;
@@ -113,10 +114,21 @@
   }
 }
 
+.fullscreenBttn {
+  display: flex;
+  border: 1px solid #999999;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  justify-content: center;
+  align-items: center;
+}
+
 .stage > :global(.__swingset-headline) {
   margin-bottom: 35px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
 }
 
 .stage > :global(.__swingset-headline) h1:first-child {

--- a/style.module.css
+++ b/style.module.css
@@ -21,6 +21,12 @@
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
+  transform: translateX(0);
+  transition: transform .2s;
+
+  &.isFullscreen {
+    transform: translateX(-250px);
+  }
 }
 
 .sidebar > * {
@@ -99,9 +105,12 @@
 
 .stage {
   padding: 20px 30px 30px;
-  float: left;
-  width: calc(100% - 350px);
   margin-left: 270px;
+  transition: margin-left .5s;
+
+  &.isFullscreen {
+    margin-left: 0;
+  }
 }
 
 .stage > :global(.__swingset-headline) {

--- a/style.module.css
+++ b/style.module.css
@@ -125,6 +125,8 @@
   height: 32px;
   justify-content: center;
   align-items: center;
+  padding: 0;
+  backround-color: transparent;
 }
 
 .stage > :global(.__swingset-headline) {

--- a/style.module.css
+++ b/style.module.css
@@ -107,7 +107,7 @@
   position: relative;
   padding: 20px 30px 30px;
   margin-left: 270px;
-  transition: margin-left .5s;
+  transition: margin-left .2s;
 
   &.isFullscreen {
     margin-left: 0;
@@ -115,6 +115,9 @@
 }
 
 .fullscreenBttn {
+  position: absolute;
+  top: 20px;
+  right: 30px;
   display: flex;
   border: 1px solid #999999;
   border-radius: 4px;


### PR DESCRIPTION
## Description
### Problem
Currently, `swingset` renders a fixed width sidebar and main content area. Since the sidebar's width is fixed across all screen widths, this constrains the width of the main content area which in turn causes visual bugs on smaller viewports. This complicates visual QA/testing for mobile and tablet.

_Example_
<img width="891" alt="Screen Shot 2022-12-07 at 8 34 56 PM" src="https://user-images.githubusercontent.com/39201593/206357442-fae28280-4eac-484f-93c2-4ce4f3246710.png"> 

### Solution

This PR adds a button that, when clicked, hides the sidebar and expands the content area. It's not a particularly elegant implementation, but it gets the job done.

<img width="636" alt="Screen Shot 2022-12-07 at 8 44 57 PM" src="https://user-images.githubusercontent.com/39201593/206358754-11644a4e-2191-45c9-b470-0879950a08e5.png">


## Validation Steps
- Navigate to the `react-components` [preview](https://react-components-git-natest-fullscreen-hashicorp.vercel.app/components/nextsteps) (using the canary release)
- Click the fullscreen button and verify that the main content area expands and the sidebar disappears
- Click the fullscreen button again and verify that the layout returns to its original state