### PR TITLE
Support Windows paths 

### DIFF
--- a/components-loader.js
+++ b/components-loader.js
@@ -29,7 +29,9 @@ module.exports = function swingsetComponentsLoader() {
   )
 
   // add components directory as a webpack dependency
-  this.addContextDependency(pluginOptions.componentsRoot.split('*')[0])
+  this.addContextDependency(
+    path.resolve(pluginOptions.componentsRoot.split('*')[0])
+  )
   const componentsWithNames = formatComponentsWithNames(usedComponents)
 
   // Resolve docs glob
@@ -138,7 +140,9 @@ function formatComponentsWithNames(components) {
  */
 function generateMetadataFile(components, docsFiles) {
   const imports = components.reduce((memo, component) => {
-    memo += `import * as ${component.name}Exports from '${component.path}'\n`
+    memo += `import * as ${
+      component.name
+    }Exports from '${component.path.replace(/\\/g, '/')}'\n`
     return memo
   }, '')
 
@@ -146,9 +150,9 @@ function generateMetadataFile(components, docsFiles) {
     // We can't just stringify here, because we need eg
     // src: Button, <<< Button NOT in quotes
     acc += `  '${component.name}': {
-      path: '${component.path}',
-      docsPath: '${path.join(component.path, 'docs.mdx')}',
-      propsPath: '${path.join(component.path, 'props.js')}',
+      path: '${component.path.replace(/\\/g, '/')}',
+      docsPath: '${path.join(component.path, 'docs.mdx').replace(/\\/g, '/')}',
+      propsPath: '${path.join(component.path, 'props.js').replace(/\\/g, '/')}',
       slug: '${component.slug}',
       exports: ${component.name}Exports,
       data: ${JSON.stringify(component.data, null, 2)}

--- a/index.js
+++ b/index.js
@@ -24,17 +24,21 @@ function withSwingset(pluginOptions = {}) {
        */
       webpack(config, options) {
         // normalize componentsRoot path
-        pluginOptions.componentsRoot = path.resolve(
-          config.context,
-          pluginOptions.componentsRoot
-            ? pluginOptions.componentsRoot
-            : 'components/*'
-        )
+        pluginOptions.componentsRoot = path
+          .resolve(
+            config.context,
+            pluginOptions.componentsRoot
+              ? pluginOptions.componentsRoot
+              : 'components/*'
+          )
+          .replace(/\\/g, '/')
         // normalize docsRoot path
-        pluginOptions.docsRoot = path.resolve(
-          config.context,
-          pluginOptions.docsRoot ? pluginOptions.docsRoot : 'docs/*'
-        )
+        pluginOptions.docsRoot = path
+          .resolve(
+            config.context,
+            pluginOptions.docsRoot ? pluginOptions.docsRoot : 'docs/*'
+          )
+          .replace(/\\/g, '/')
         //
         config.module.rules.push({
           test: /__swingset_data/,


### PR DESCRIPTION
Building on #37 (👏) and as mentioned in #54 this PR supports Windows paths with a simple regex

Main differences from #37 are the following (since it is up to date w/ `main`):
- We're now only calling `this.addContextDependency` once as opposed to previous per component approach
- `component.path` is also normalized within the template literal (within `generateMetadataFile` function)

Examples are now working for me locally on Windows

<img width="320" alt="image" src="https://user-images.githubusercontent.com/7191639/218524744-beda3f53-86f7-4d12-887c-6e83dff26a3f.png">

### 📌 Note
We did have a super [simple util function on `next-mdx-enhanced`](https://github.com/hashicorp/next-mdx-enhanced/blob/main/util.js#L41) for this sort of thing. Let me know if that is preferred!

