### PR TITLE
feat: use `title` from frontmatter in categories data, if defined

### DIFF
--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -1,4 +1,5 @@
 ---
+title: 'Button'
 description: The button is used widely across HashiCorp properties, and has many ways it can be customized. Let's start with its most basic form.
 ---
 import { Button } from '.'

--- a/examples/basic/components/card/docs.mdx
+++ b/examples/basic/components/card/docs.mdx
@@ -1,4 +1,5 @@
 ---
+title: 'Card'
 description: A container for all sorts of things.
 category: "content"
 ---

--- a/examples/basic/components/text-input/docs.mdx
+++ b/examples/basic/components/text-input/docs.mdx
@@ -1,4 +1,5 @@
 ---
+title: 'TextInput'
 description: 'A text input'
 ---
 

--- a/examples/basic/components/text/docs.mdx
+++ b/examples/basic/components/text/docs.mdx
@@ -1,3 +1,7 @@
+---
+title: 'Text'
+---
+
 import Text from '.'
 
 <Text>Hi</Text>

--- a/packages/swingset-theme-hashicorp/src/components/props-table.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/props-table.tsx
@@ -17,8 +17,12 @@ function InlineCode({ children }: { children: ReactNode }) {
 }
 
 export function PropsTable({ component }: PropsTableProps) {
-  console.log(component.propsMetadata)
+  if (!component?.propsMetadata?.props) {
+    return null
+  }
+
   const headers = ['Name', 'Type', 'Description', 'Required']
+
   const rows = Object.entries(component.propsMetadata.props).map(
     ([key, data]: [string, any]) => (
       <tr key={key}>

--- a/packages/swingset-theme-hashicorp/src/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/index.tsx
@@ -27,11 +27,13 @@ export default function SwingsetLayout({
                       <li>
                         <h3 className="ss-my-2 ss-text-gray-600">{title}</h3>
                       </li>
-                      {(items as string[]).map((slug: string) => (
-                        <li>
-                          <Link href={`/swingset/${slug}`}>{slug}</Link>
-                        </li>
-                      ))}
+                      {(items as { title: string; slug: string }[]).map(
+                        ({ title, slug }) => (
+                          <li>
+                            <Link href={`/swingset/${slug}`}>{title}</Link>
+                          </li>
+                        )
+                      )}
                     </>
                   ))}
                 </ul>

--- a/packages/swingset/src/get-categories.ts
+++ b/packages/swingset/src/get-categories.ts
@@ -2,14 +2,14 @@ import { ComponentEntity, DocsEntity } from './types'
 
 // TODO: sort
 export function getCategories(entities: (ComponentEntity | DocsEntity)[]) {
-  let result: Record<string, string[]> = {}
+  let result: Record<string, Pick<ComponentEntity, 'title' | 'slug'>[]> = {}
 
   for (const entity of entities.filter(
     (entity) => entity.__type === 'component'
   ) as ComponentEntity[]) {
     result[entity.category] ||= []
 
-    result[entity.category].push(entity.slug)
+    result[entity.category].push({ title: entity.title, slug: entity.slug })
   }
 
   return result

--- a/packages/swingset/src/loader.ts
+++ b/packages/swingset/src/loader.ts
@@ -108,7 +108,6 @@ export const frontmatter = ${stringifiedFrontmatter};
 
   // Append prop metadata to a component when imported from an mdx file
   if (isComponentImport) {
-    console.log(source)
     const propsMetadata = await getRelatedComponentPropsMetadata({
       source,
       filepath: context.resourcePath,

--- a/packages/swingset/src/resolvers/component.ts
+++ b/packages/swingset/src/resolvers/component.ts
@@ -37,6 +37,7 @@ export async function resolveComponents({
       __type: 'component',
       frontmatter,
       category: (frontmatter.category as string) ?? 'default',
+      title: (frontmatter.title as string) ?? componentSlug,
       filepath,
       relativePath,
       normalizedPath,

--- a/packages/swingset/src/types.ts
+++ b/packages/swingset/src/types.ts
@@ -15,6 +15,7 @@ export interface ComponentEntity extends Entity {
   category: string
   componentPath: string
   slug: string
+  title: string
 }
 
 export interface DocsEntity extends Entity {


### PR DESCRIPTION
Adds a new `title` property to the `ComponentEntity`. If `title` is defined in frontmatter, this will use that value. Otherwise, it will fallback to the generated `slug`. Use this value when generating the categories data, and update `swingset-theme-hashicorp` to use the new property.