### PR TITLE
fix: ensure global theme CSS is loaded first

### DIFF
--- a/packages/swingset-theme-hashicorp/src/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/index.tsx
@@ -1,4 +1,4 @@
-// NOTE: global css import needs to be at the top so component-specific CSS is loaded after the theme reset
+// NOTE: global css import needs to be at the top so component-specific CSS is loaded after the theme reset (component-specific CSS is loaded as a result of the swingset/meta import below)
 import '../style.css'
 
 import React from 'react'

--- a/packages/swingset-theme-hashicorp/src/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/index.tsx
@@ -1,11 +1,12 @@
+// NOTE: global css import needs to be at the top so component-specific CSS is loaded after the theme reset
+import '../style.css'
+
 import React from 'react'
 import Link from 'next/link'
 import { meta, categories } from 'swingset/meta'
 import { cx } from 'class-variance-authority'
 
 import Page from './page'
-
-import '../style.css'
 
 function NavList({ items, level }: any) {
   const isNested = level > 0


### PR DESCRIPTION
Updates `swingset-theme-hashicorp` to import its global CSS file first, ensuring any other CSS is concatenated _after_ the global declarations.

fixes https://github.com/hashicorp/swingset/issues/95