### PR TITLE
fix: use turbo to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
           key: "${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}"
           restore-keys: '${{ runner.os }}-node-'
       - run: npm ci
-      - run: npm run test
+      - run: npx turbo run test --concurrency 1 --continue


### PR DESCRIPTION
This PR adjusts the CI test workflow to run tests via turborepo instead of the root-level `test` script (which should probably be updated anyway).

I'm not sure if vitest likes being run in parallel. Running `npx turbo run test` without any additional arguments resulted in a strange error:

```
➜  swingset git:(feat/component-path-parse) npx turbo run test                  
╭───────────────────────────────────────────────────────────────────────╮
│                                                                       │
│                  Update available v1.10.0 ≫ v1.10.2                   │
│    Changelog: https://github.com/vercel/turbo/releases/tag/v1.10.2    │
│               Run "npx @turbo/codemod update" to update               │
│                                                                       │
│     Follow @turborepo for updates: https://twitter.com/turborepo      │
╰───────────────────────────────────────────────────────────────────────╯
• Packages in scope: example-basic, swingset, swingset-theme-hashicorp
• Running test in 3 packages
• Remote caching disabled
swingset:test: cache miss, executing dffe2b393988a9e6
swingset-theme-hashicorp:test: cache miss, executing cb05d17813774ffa
swingset:test: 
swingset:test: > swingset@0.17.0 test
swingset:test: > vitest run
swingset:test: 
swingset-theme-hashicorp:test: 
swingset-theme-hashicorp:test: > swingset-theme-hashicorp@0.0.0 test
swingset-theme-hashicorp:test: > vitest run
swingset-theme-hashicorp:test: 
swingset:test: 
swingset:test:  RUN  v0.31.3 /home/dstaley/git/hashicorp/swingset/packages/swingset
swingset:test: 
swingset-theme-hashicorp:test: 
swingset-theme-hashicorp:test:  RUN  v0.31.3 /home/dstaley/git/hashicorp/swingset/packages/swingset-theme-hashicorp
swingset-theme-hashicorp:test: 
swingset-theme-hashicorp:test: include: **/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}
swingset-theme-hashicorp:test: exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*
swingset-theme-hashicorp:test: watch exclude:  **/node_modules/**, **/dist/**
swingset-theme-hashicorp:test: 
swingset-theme-hashicorp:test: No test files found, exiting with code 1
swingset-theme-hashicorp:test: npm ERR! Lifecycle script `test` failed with error: 
swingset-theme-hashicorp:test: npm ERR! Error: command failed 
swingset-theme-hashicorp:test: npm ERR!   in workspace: swingset-theme-hashicorp@0.0.0 
swingset-theme-hashicorp:test: npm ERR!   at location: /home/dstaley/git/hashicorp/swingset/packages/swingset-theme-hashicorp 
swingset-theme-hashicorp:test: ERROR: command finished with error: command (/home/dstaley/git/hashicorp/swingset/packages/swingset-theme-hashicorp) npm run test exited (1)
swingset:test:  ❯ __tests__/parse-component-path.test.ts  (0 test)
swingset:test:  ❯ __tests__/index.test.ts  (0 test)
swingset:test: 
swingset:test: ⎯⎯⎯⎯⎯⎯ Failed Suites 2 ⎯⎯⎯⎯⎯⎯⎯
swingset:test: 
swingset:test:  FAIL  __tests__/index.test.ts [ __tests__/index.test.ts ]
swingset:test:  FAIL  __tests__/parse-component-path.test.ts [ __tests__/parse-component-path.test.ts ]
swingset:test: Error: The service is no longer running
swingset:test:  ❯ ../../node_modules/esbuild/lib/main.js:816:29
swingset:test:  ❯ sendRequest ../../node_modules/esbuild/lib/main.js:693:14
swingset:test:  ❯ start ../../node_modules/esbuild/lib/main.js:814:9
swingset:test:  ❯ Object.transform2 [as transform] ../../node_modules/esbuild/lib/main.js:879:5
swingset:test:  ❯ ../../node_modules/esbuild/lib/main.js:2180:77
swingset:test:  ❯ Object.transform ../../node_modules/esbuild/lib/main.js:2180:36
swingset:test:  ❯ transform ../../node_modules/esbuild/lib/main.js:2013:62
swingset:test:  ❯ transformWithEsbuild ../../node_modules/vite/dist/node/chunks/dep-e8f070e8.js:13796:30
swingset:test:  ❯ TransformContext.transform ../../node_modules/vite/dist/node/chunks/dep-e8f070e8.js:13866:32
swingset:test: 
swingset:test: ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
swingset:test: 
swingset:test:  Test Files  2 failed (2)
swingset:test:       Tests  no tests
swingset:test:    Start at  11:01:54
swingset:test:    Duration  941ms (transform 22ms, setup 0ms, collect 0ms, tests 0ms, environment 0ms, prepare 148ms)
swingset:test: 
command (/home/dstaley/git/hashicorp/swingset/packages/swingset-theme-hashicorp) npm run test exited (1)

 Tasks:    0 successful, 2 total
Cached:    0 cached, 2 total
  Time:    1.565s 
Failed:    swingset-theme-hashicorp#test

 ERROR  run failed: command  exited (1)
```

So just to get things working I limited the concurrency to 1 and instructed Turbo to continue even if one of the workspaces failed.