### PR TITLE
docs: add section on debugging the example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ node_modules
 .next
 .yalc
 yalc.lock
-.vscode
+.vscode/*
 
 !.vscode/launch.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules
 yalc.lock
 .vscode
 
+!.vscode/launch.json
+
 # Turbo
 */**/.turbo
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ node_modules
 .next
 .yalc
 yalc.lock
-.vscode/*
 
+# VS Code
+.vscode/*
 !.vscode/launch.json
 
 # Turbo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node-terminal",
       "request": "launch",
       "command": "npx next dev",
-      "cwd": "${workspaceFolder}/examples/basic"
+      "cwd": "${workspaceFolder}${pathSeparator}examples${pathSeparator}basic"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug examples/basic app",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npx next dev",
+      "cwd": "${workspaceRoot}/examples/basic"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "node-terminal",
       "request": "launch",
       "command": "npx next dev",
-      "cwd": "${workspaceRoot}/examples/basic"
+      "cwd": "${workspaceFolder}/examples/basic"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ First, run the `dev` task for `example-basic`'s dependencies:
 npx turbo run dev --filter example-basic^...
 ```
 
-Next, open the VSCode debug panel (`Ctrl+Shift+D` on Windows/Linux, `⇧+⌘+D` on macOS) and run the `Debug examples/basic app` launch configuration. This will start Next's development process and attach a debugger. Any `debugger;` statements you have added in Swingset's core should be triggered.
+Next, open the VSCode debug panel (`Ctrl+Shift+D` on Windows/Linux, `⇧+⌘+D` on macOS) and run the `Debug examples/basic app` launch configuration. This will start Next's development process and attach a debugger. Any [`debugger;`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) statements you have added in Swingset's core should be triggered.
 
 ## Custom themes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,18 @@ npx turbo run dev --filter example-basic...
 
 Finally, visit <http://localhost:3000/swingset> in your browser. Any changes to the core `swingset` package will be rebuilt and reflect in the running example app.
 
+## Debugging the example app
+
+If you are iterating on the loader code, it might be helpful to use the Node debugger instead of relying on `console.log()` statements. To make this easier, we have included a VSCode launch configuration.
+
+First, run the `dev` task for `example-basic`'s dependencies:
+
+```shell-session
+npx turbo run dev --filter example-basic^...
+```
+
+Next, open the VSCode debug panel (`Ctrl+Shift+D` on Windows/Linux, `⇧+⌘+D` on macOS) and run the `Debug examples/basic app` launch configuration.
+
 ## Custom themes
 
 Swingset on its own is an unstyled core, exposing the data and utilities necessary to build your component documentation. To render a UI, swingset relies on themes. A theme exposes a number of components that swingset will use to render its UI. Currently, a theme must expose number of exports to render the full UI:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Finally, visit <http://localhost:3000/swingset> in your browser. Any changes to 
 
 ## Debugging the example app
 
-If you are iterating on the loader code, it might be helpful to use the Node debugger instead of relying on `console.log()` statements. To make this easier, we have included a VSCode launch configuration.
+If you are iterating on the loader code, it might be helpful to use the Node.js [Debugger](https://nodejs.org/api/debugger.html) instead of relying on `console.log()` statements. To make this easier, we have included a VSCode launch configuration.
 
 First, run the `dev` task for `example-basic`'s dependencies:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ First, run the `dev` task for `example-basic`'s dependencies:
 npx turbo run dev --filter example-basic^...
 ```
 
-Next, open the VSCode debug panel (`Ctrl+Shift+D` on Windows/Linux, `⇧+⌘+D` on macOS) and run the `Debug examples/basic app` launch configuration.
+Next, open the VSCode debug panel (`Ctrl+Shift+D` on Windows/Linux, `⇧+⌘+D` on macOS) and run the `Debug examples/basic app` launch configuration. This will start Next's development process and attach a debugger. Any `debugger;` statements you have added in Swingset's core should be triggered.
 
 ## Custom themes
 

--- a/packages/swingset/src/loader.ts
+++ b/packages/swingset/src/loader.ts
@@ -67,9 +67,7 @@ export async function loader(
     const result = `
       export const meta = {
         ${entities
-          .map(
-            (entity) => `'${entity.slug}': ${stringifyEntity(entity)}`
-          )
+          .map((entity) => `'${entity.slug}': ${stringifyEntity(entity)}`)
           .join(',\n')}
       };
 


### PR DESCRIPTION
Updates the `CONTRIBUTING.md` file with a section on debugging the example app with VSCode. I've also included a `.vsocde/launch.json` file with a configuration for running the example app.