### PR TITLE
Tests for `getNavigationTree`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "prerelease:canary": "turbo build",
     "release": "changeset publish",
     "release:canary": "changeset publish --tag canary",
-    "test": "jest"
+    "test": "npx turbo run test --concurrency 1 --continue"
   }
 }

--- a/packages/swingset/__tests__/get-nav-tree.test.ts
+++ b/packages/swingset/__tests__/get-nav-tree.test.ts
@@ -1,0 +1,101 @@
+import { describe, it } from 'vitest'
+import { getNavigationTree } from '../src/get-nav-tree'
+import { ComponentNode, ComponentEntity, NavigationTree } from '../src/types'
+
+describe(getNavigationTree.name, () => {
+  it('Builds the Navigation Tree', ({ expect }) => {
+    const input: ComponentEntity[] = [
+      {
+        __type: 'component',
+        category: 'default',
+        componentPath: '../../..',
+        filepath: '../../..',
+        frontmatter: {},
+        normalizedPath: '',
+        relativePath: '',
+        slug: '',
+        title: '',
+        load: '',
+      },
+    ]
+
+    const expectation: NavigationTree = [
+      {
+        children: [
+          {
+            __type: 'component',
+            componentPath: '../../..',
+            slug: '',
+            title: '',
+          },
+        ],
+        title: 'default',
+        type: 'category',
+      },
+    ]
+
+    const result = getNavigationTree(input)
+
+    expect(result).toEqual(expectation)
+  })
+  it('Supports duplicate entities', ({ expect }) => {
+    const input: ComponentEntity[] = [
+      {
+        __type: 'component',
+        category: 'default',
+        componentPath: '../../..',
+        filepath: '../../..',
+        frontmatter: {},
+        normalizedPath: '',
+        relativePath: '',
+        slug: '',
+        title: '',
+        load: '',
+      },
+      {
+        __type: 'component',
+        category: 'default',
+        componentPath: '../../..',
+        filepath: '../../..',
+        frontmatter: {},
+        normalizedPath: '',
+        relativePath: '',
+        slug: '',
+        title: '',
+        load: '',
+      },
+    ]
+
+    const expectation: NavigationTree = [
+      {
+        children: [
+          {
+            __type: 'component',
+            componentPath: '../../..',
+            slug: '',
+            title: '',
+          },
+          {
+            __type: 'component',
+            componentPath: '../../..',
+            slug: '',
+            title: '',
+          },
+        ],
+        title: 'default',
+        type: 'category',
+      },
+    ]
+
+    const result = getNavigationTree(input)
+
+    expect(result).toEqual(expectation)
+  })
+  it('Returns an empty array if it receives one', ({ expect }) => {
+    const input: ComponentEntity[] = []
+    const expectation: NavigationTree = []
+    const result = getNavigationTree(input)
+
+    expect(result).toEqual(expectation)
+  })
+})

--- a/packages/swingset/__tests__/index.test.ts
+++ b/packages/swingset/__tests__/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it } from 'vitest'
-
-describe('tests', () => {
-  it('works', ({ expect }) => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/swingset/__tests__/parse-component-path.test.ts
+++ b/packages/swingset/__tests__/parse-component-path.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from 'vitest'
 import { parseComponentPath } from '../src/parse-component-path'
 
-describe('parseComponentPath', () => {
-  it('converts the front matter string to an object', ({ expect }) => {
+describe(parseComponentPath.name, () => {
+  it('Converts a 3 segment path to a navigationData object', ({ expect }) => {
     const expectation = {
       category: 'Components',
       folder: 'Forms',
@@ -13,7 +13,7 @@ describe('parseComponentPath', () => {
 
     expect(result).toEqual(expectation)
   })
-  it('converts the front matter string to an object', ({ expect }) => {
+  it('Converts a 2 segment path to a navigationData object', ({ expect }) => {
     const expectation = {
       category: 'Components',
       page: 'Button',
@@ -23,8 +23,9 @@ describe('parseComponentPath', () => {
 
     expect(result).toEqual(expectation)
   })
-  it('converts the front matter string to an object', ({ expect }) => {
+  it('Converts a 1 segment path to a navigationData object', ({ expect }) => {
     const expectation = {
+      category: 'default',
       page: 'Button',
     }
 
@@ -32,10 +33,9 @@ describe('parseComponentPath', () => {
 
     expect(result).toEqual(expectation)
   })
-  it('Throws an error when invalid input is received', ({expect}) => {
+  it('Throws an error when too many segments are received', ({ expect }) => {
+    const input = 'edibles/fruits/berries/blueberries'
 
-    expect(() => parseComponentPath('edibles/fruits/berries/blueberries')).toThrowError()
-   
-    
+    expect(() => parseComponentPath(input)).toThrowError()
   })
 })


### PR DESCRIPTION
### Summary

Solves #108 

1. Updates default `npm run test` command
2. Rewrites old tests for `parseComponentPath` to be more descriptive
3. Adds new tests for `getNavigationTree` to ensure method continues to work when sorting is introduced