### PR TITLE
Configure `es-lint`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  root: true,
+  extends: './node_modules/@hashicorp/platform-cli/config/.eslintrc.js',
+  /* Specify overrides here */
+}

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@hashicorp/platform-cli/config/stylelint.config']
+}

--- a/packages/swingset-theme-hashicorp/.eslintrc.cjs
+++ b/packages/swingset-theme-hashicorp/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: require.resolve('@hashicorp/platform-cli/config/.eslintrc.js'),
+  rules: {
+    '@next/next/no-html-link-for-pages': 'off',
+  },
+  /* Specify overrides here */
+}

--- a/packages/swingset-theme-hashicorp/.stylelintrc.js
+++ b/packages/swingset-theme-hashicorp/.stylelintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@hashicorp/platform-cli/config/stylelint.config'],
+}

--- a/packages/swingset-theme-hashicorp/tsconfig.json
+++ b/packages/swingset-theme-hashicorp/tsconfig.json
@@ -14,6 +14,6 @@
     "types": ["vitest/globals", "webpack-env"],
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "stylintrc.js"],
   "exclude": ["dist/**/*"]
 }

--- a/packages/swingset/.eslintrc.cjs
+++ b/packages/swingset/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: require.resolve('@hashicorp/platform-cli/config/.eslintrc.js'),
+  rules: {
+    '@next/next/no-html-link-for-pages': 'off',
+  },
+  /* Specify overrides here */
+}

--- a/packages/swingset/.stylelintrc.js
+++ b/packages/swingset/.stylelintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@hashicorp/platform-cli/config/stylelint.config'],
+}

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,9 @@
       "cache": false,
       "persistent": true
     },
-    "test": {}
+    "test": {},
+    "lint": {
+      "cache": false
+    }
   }
 }


### PR DESCRIPTION
This PR configures `es-lint` with the `@hashicorp/platform-cli` package. 


>**Note** 
I attempted to pattern matching with the `hashcorp/web` repo and thus all the config settings are mirroring there but I'm receiving an error when mixing `.cjs` with ES6 modules