### PR TITLE
fix: add turbo config for example app to configure cache outputs

### DIFF
--- a/examples/basic/turbo.json
+++ b/examples/basic/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**/*"]
+      "outputs": ["dist/**/*", "style.css"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Ensure the example app's outputs are cached by turbo to avoid cached build failures.