### PR TITLE
LiveComponent Kickoff 🎉

### DIFF
--- a/examples/basic/app/(swingset)/swingset/content.mdx
+++ b/examples/basic/app/(swingset)/swingset/content.mdx
@@ -20,7 +20,7 @@ Success! Route group created:
 (swingset)
   ├ /layout.tsx
   └ /swingset
-    ├ /page.tsx 
+    ├ /page.tsx
     └ /[...path]
       └ /page.tsx
 ```
@@ -40,7 +40,7 @@ components/
 
 Swingset automatically exposes prop metadata for components imported into your documentation.
 
-```typescript
+```tsx
 <PropsTable component={Button} />
 ```
 
@@ -75,20 +75,57 @@ Want to add support for GitHub Flavored Markdown? Swingset accepts `remark` and 
 - [x] Restart your server
 - [ ] Render task lists!
 
-
 ```js
 import withSwingset from 'swingset'
 import remarkGfm from 'remark-gfm'
 
 export default withSwingset({
   componentRoot: './components',
-  remarkPlugins: [remarkGfm]
+  remarkPlugins: [remarkGfm],
 })({
   experimental: {
     appDir: true,
   },
 })
 ```
+
+### Inline Playgrounds
+
+Swingset allows you to inspect how components behave right here in the docs. Here's an example using [MUI](https://mui.com/).
+
+<LiveComponent deps={{
+  "@mui/material":"latest",
+  "@emotion/react": "latest",
+  "@emotion/styled": "latest"
+}}>
+
+```tsx filePath="App.tsx"
+import * as React from 'react'
+import Button from './components/Button.tsx'
+
+export default function MyApp() {
+  return (
+    <div>
+      <Button variant="outline">Button</Button>
+    </div>
+  )
+}
+```
+
+```tsx filePath="components/Button.tsx"
+import * as React from 'react'
+import MUIButton from '@mui/material/Button'
+
+export default function Button() {
+  return (
+    <div>
+      <MUIButton variant="contained">Button</MUIButton>
+    </div>
+  )
+}
+```
+
+</LiveComponent>
 
 ### Integrates with `@next/mdx`
 

--- a/examples/basic/app/(swingset)/swingset/content.mdx
+++ b/examples/basic/app/(swingset)/swingset/content.mdx
@@ -91,7 +91,45 @@ export default withSwingset({
 
 ### Inline Playgrounds
 
-Swingset allows you to inspect how components behave right here in the docs. Here's an example using [MUI](https://mui.com/).
+Swingset allows you to inspect how components behave right here in the docs. By using Codesandbox's bundler it supports packages on the npm public registry. Here's an example using [MUI](https://mui.com/).
+
+````
+<LiveComponent deps={{
+  "@mui/material":"latest",
+  "@emotion/react": "latest",
+  "@emotion/styled": "latest"
+}}>
+
+```tsx filePath="App.tsx"
+import * as React from 'react'
+import Button from './components/Button.tsx'
+
+export default function MyApp() {
+  return (
+    <div>
+      <Button variant="outline">Button</Button>
+    </div>
+  )
+}
+```
+
+```tsx filePath="components/Button.tsx"
+import * as React from 'react'
+import MUIButton from '@mui/material/Button'
+
+export default function Button() {
+  return (
+    <div>
+      <MUIButton variant="contained">Button</MUIButton>
+    </div>
+  )
+}
+```
+
+</LiveComponent>
+````
+
+Will render the following
 
 <LiveComponent deps={{
   "@mui/material":"latest",

--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -2,12 +2,30 @@
 title: 'Button'
 description: The button is used widely across HashiCorp properties, and has many ways it can be customized. Let's start with its most basic form.
 ---
+
 import { Button } from '.'
 
-export const Simple = () => (<Button>Click me</Button>)
+export const Simple = () => <Button>Click me</Button>
 
 ## Simple
 
 <Simple />
 
 <PropsTable component={Button} />
+
+```ts
+const hey = 'hey'
+```
+
+<LiveComponent>
+
+```ts filePath="Tapp.tsx"
+export default function App({ data }) {
+  if (data) {
+    return <p>Hello {data}</p>
+  }
+  return <p>Hello World</p>
+}
+```
+
+</LiveComponent>

--- a/examples/basic/components/button/docs.mdx
+++ b/examples/basic/components/button/docs.mdx
@@ -12,20 +12,3 @@ export const Simple = () => <Button>Click me</Button>
 <Simple />
 
 <PropsTable component={Button} />
-
-```ts
-const hey = 'hey'
-```
-
-<LiveComponent>
-
-```ts filePath="Tapp.tsx"
-export default function App({ data }) {
-  if (data) {
-    return <p>Hello {data}</p>
-  }
-  return <p>Hello World</p>
-}
-```
-
-</LiveComponent>

--- a/examples/basic/mdx-components.js
+++ b/examples/basic/mdx-components.js
@@ -1,4 +1,4 @@
-import themeComponents from 'swingset-theme-hashicorp/components'
+import themeComponents from 'swingset-theme-hashicorp/MDXComponents'
 
 export function useMDXComponents(components) {
   // Allows customizing built-in components, e.g. to add styling.

--- a/examples/basic/next.config.mjs
+++ b/examples/basic/next.config.mjs
@@ -1,10 +1,12 @@
 import withSwingset from 'swingset'
 import remarkGfm from 'remark-gfm'
+import rehypeMdxCodeProps from 'rehype-mdx-code-props'
 
 export default withSwingset({
   componentRootPattern: './components',
   theme: 'swingset-theme-hashicorp',
   remarkPlugins: [remarkGfm],
+  rehypePlugins: [rehypeMdxCodeProps],
 })({
   experimental: {
     appDir: true,

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,7 @@
     "next": "^13.4.4",
     "react": "*",
     "react-dom": "*",
+    "rehype-mdx-code-props": "^1.0.0",
     "remark-gfm": "^3.0.1",
     "swingset": "file:../../packages/swingset",
     "swingset-theme-hashicorp": "file:../../packages/swingset-theme-hashicorp"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "next": "^13.4.4",
         "react": "*",
         "react-dom": "*",
+        "rehype-mdx-code-props": "^1.0.0",
         "remark-gfm": "^3.0.1",
         "swingset": "file:../../packages/swingset",
         "swingset-theme-hashicorp": "file:../../packages/swingset-theme-hashicorp"
@@ -948,6 +949,171 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.8.1.tgz",
+      "integrity": "sha512-HpphvDcTdOx+9R3eUw9hZK9JA77jlaBF0kOt2McbyfvY0rX9pnMoO8rkkZc0GzSbzhIY4m5xJ0uHHgjfqHNmXQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.6.0",
+        "@lezer/common": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.5.tgz",
+      "integrity": "sha512-dUCSxkIw2G+chaUfw3Gfu5kkN83vJQN8gfQDp9iEHsIZluMJA0YJveT12zg/28BJx+uPsbQ6VimKCgx3oJrZxA==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
+      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
+      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.14.1.tgz",
+      "integrity": "sha512-ofcsI7lRFo4N0rfnd+V3Gh2boQU3DmaaSKhDOvXUWjeOeuupMXer2e/3i9TUFN7aEIntv300EFBWPEiYVm2svg==",
+      "dependencies": {
+        "@codemirror/state": "^6.1.4",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "dependencies": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-client": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.6.9.tgz",
+      "integrity": "sha512-koDZF/x8Gn7EhnxuyMRxbWrEW/e0/QnPkTtO8PNf4FyPDUITHvBzdjkzefvMLX6wn4aA4knpkLnKfPHMl4BhWA==",
+      "dependencies": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.6.9.tgz",
+      "integrity": "sha512-JAbpc1emb9lGdZ0zfnfQnJmU91IcH1AUOmoVevB2qwdrxeaQWy5DyKyqRaQDcMyPicXSXMUF6nvDhb0HY34ofw==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/commands": "^6.1.3",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.4.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.3.2",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.7.1",
+        "@codesandbox/sandpack-client": "^2.6.9",
+        "@lezer/highlight": "^1.1.3",
+        "@react-hook/intersection-observer": "^3.1.1",
+        "@stitches/core": "^1.2.6",
+        "anser": "^2.1.1",
+        "clean-set": "^1.1.2",
+        "codesandbox-import-util-types": "^2.2.3",
+        "dequal": "^2.0.2",
+        "escape-carriage": "^1.3.1",
+        "lz-string": "^1.4.4",
+        "react-devtools-inline": "4.4.0",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@codesandbox/sandpack-react/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.8",
@@ -2165,6 +2331,55 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.3.tgz",
+      "integrity": "sha512-SjSM4pkQnQdJDVc80LYzEaMiNy9txsFbI7HsMgeVF28NdLaAdHNtQ+kB/QqDUzRBV/75NTXjJ/R5IdC8QQGxMg==",
+      "dependencies": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.5.tgz",
+      "integrity": "sha512-pUX9Y2HJiFGQdkDfLjN8dwR8jSxz/XYY/JmUiaoEAb+kvw0ZU63hRe0+k04fbyvg1208R2EltJ1v7IUHE0G1NA==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.4.tgz",
+      "integrity": "sha512-0BiBjpEcrt2IXrIzEAsdTLylrVhGHRqVQL3baTBx1sf4qewjIvhG1/pTUumu7W/7YR0AASjLQOQxFmo5EvNmzQ==",
+      "dependencies": {
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
+      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -2431,6 +2646,31 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz",
+      "integrity": "sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA=="
+    },
+    "node_modules/@react-hook/intersection-observer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz",
+      "integrity": "sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==",
+      "dependencies": {
+        "@react-hook/passive-layout-effect": "^1.2.0",
+        "intersection-observer": "^0.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -2454,6 +2694,11 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.1",
@@ -2680,6 +2925,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -3119,6 +3369,11 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/anser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.1.1.tgz",
+      "integrity": "sha512-nqLm4HxOTpeLOxcmB3QWmV5TcDFhW9y/fyQ+hivtDFcK4OQ+pQ5fzPnXHM1Mfcm0VkLtvVi1TCPr++Qy0Q/3EQ=="
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -3443,6 +3698,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -3551,6 +3825,29 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3840,6 +4137,11 @@
         }
       }
     },
+    "node_modules/clean-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+      "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3929,6 +4231,11 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
+    },
+    "node_modules/codesandbox-import-util-types": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/codesandbox-import-util-types/-/codesandbox-import-util-types-2.2.3.tgz",
+      "integrity": "sha512-Qj00p60oNExthP2oR3vvXmUGjukij+rxJGuiaKM6tyUmSyimdZsqHI/TUvFFClAffk9s7hxGnQgWQ8KCce27qQ=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -4168,6 +4475,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4248,6 +4560,15 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "node_modules/data-urls": {
       "version": "2.0.0",
@@ -4695,6 +5016,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.17.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.8.tgz",
@@ -4739,6 +5093,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw=="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -5054,6 +5413,19 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5566,6 +5938,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -5645,6 +6036,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ=="
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -8453,6 +8849,14 @@
         "yallist": "^2.1.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -9735,6 +10139,11 @@
         }
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -9900,6 +10309,11 @@
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
       "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
       "dev": true
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw=="
     },
     "node_modules/p-filter": {
       "version": "2.1.0",
@@ -10544,6 +10958,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/prism-react-renderer": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.6.tgz",
+      "integrity": "sha512-ERzmAI5UvrcTw5ivfEG20/dYClAsC84eSED5p9X3oKpm0xPV4A5clFK1mp7lPIdKmbLnQYsPTGiOI7WS6gWigw==",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10651,6 +11077,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-devtools-inline": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
+      "integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
+      "dependencies": {
+        "es6-symbol": "^3"
       }
     },
     "node_modules/react-docgen": {
@@ -10850,6 +11284,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-mdx-code-props": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-mdx-code-props/-/rehype-mdx-code-props-1.0.0.tgz",
+      "integrity": "sha512-NvHm7pTqIIfhpKmjNNizIIJzOcaRDvsAI2katLLylxX5DdhTw/sYKTKnvVZTungykXQglcYnlyVglsEuZ/jZxA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "hast-util-to-estree": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
       }
     },
     "node_modules/remark-gfm": {
@@ -11497,6 +11947,36 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "node_modules/static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      }
+    },
+    "node_modules/static-browser-server/node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/static-browser-server/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
@@ -11519,6 +11999,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -11635,6 +12120,11 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "node_modules/style-to-object": {
       "version": "0.4.1",
@@ -12448,6 +12938,11 @@
         "win32"
       ]
     },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -12964,6 +13459,11 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -13494,8 +13994,10 @@
     "packages/swingset-theme-hashicorp": {
       "version": "0.0.0",
       "dependencies": {
+        "@codesandbox/sandpack-react": "^2.6.9",
         "@hashicorp/flight-icons": "^2.14.0",
-        "class-variance-authority": "^0.6.0"
+        "class-variance-authority": "^0.6.0",
+        "prism-react-renderer": "^2.0.6"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",
@@ -14370,6 +14872,163 @@
         }
       }
     },
+    "@codemirror/autocomplete": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.8.1.tgz",
+      "integrity": "sha512-HpphvDcTdOx+9R3eUw9hZK9JA77jlaBF0kOt2McbyfvY0rX9pnMoO8rkkZc0GzSbzhIY4m5xJ0uHHgjfqHNmXQ==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.6.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/commands": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
+      "requires": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-css": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.0.0"
+      }
+    },
+    "@codemirror/lang-html": {
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.5.tgz",
+      "integrity": "sha512-dUCSxkIw2G+chaUfw3Gfu5kkN83vJQN8gfQDp9iEHsIZluMJA0YJveT12zg/28BJx+uPsbQ6VimKCgx3oJrZxA==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.0"
+      }
+    },
+    "@codemirror/lang-javascript": {
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "@codemirror/language": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
+      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "@codemirror/lint": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
+      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
+      "requires": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "@codemirror/state": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
+    },
+    "@codemirror/view": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.14.1.tgz",
+      "integrity": "sha512-ofcsI7lRFo4N0rfnd+V3Gh2boQU3DmaaSKhDOvXUWjeOeuupMXer2e/3i9TUFN7aEIntv300EFBWPEiYVm2svg==",
+      "requires": {
+        "@codemirror/state": "^6.1.4",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "@codesandbox/nodebox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@codesandbox/nodebox/-/nodebox-0.1.8.tgz",
+      "integrity": "sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==",
+      "requires": {
+        "outvariant": "^1.4.0",
+        "strict-event-emitter": "^0.4.3"
+      }
+    },
+    "@codesandbox/sandpack-client": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-client/-/sandpack-client-2.6.9.tgz",
+      "integrity": "sha512-koDZF/x8Gn7EhnxuyMRxbWrEW/e0/QnPkTtO8PNf4FyPDUITHvBzdjkzefvMLX6wn4aA4knpkLnKfPHMl4BhWA==",
+      "requires": {
+        "@codesandbox/nodebox": "0.1.8",
+        "buffer": "^6.0.3",
+        "dequal": "^2.0.2",
+        "outvariant": "1.4.0",
+        "static-browser-server": "1.0.3"
+      }
+    },
+    "@codesandbox/sandpack-react": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@codesandbox/sandpack-react/-/sandpack-react-2.6.9.tgz",
+      "integrity": "sha512-JAbpc1emb9lGdZ0zfnfQnJmU91IcH1AUOmoVevB2qwdrxeaQWy5DyKyqRaQDcMyPicXSXMUF6nvDhb0HY34ofw==",
+      "requires": {
+        "@codemirror/autocomplete": "^6.4.0",
+        "@codemirror/commands": "^6.1.3",
+        "@codemirror/lang-css": "^6.0.1",
+        "@codemirror/lang-html": "^6.4.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.3.2",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.7.1",
+        "@codesandbox/sandpack-client": "^2.6.9",
+        "@lezer/highlight": "^1.1.3",
+        "@react-hook/intersection-observer": "^3.1.1",
+        "@stitches/core": "^1.2.6",
+        "anser": "^2.1.1",
+        "clean-set": "^1.1.2",
+        "codesandbox-import-util-types": "^2.2.3",
+        "dequal": "^2.0.2",
+        "escape-carriage": "^1.3.1",
+        "lz-string": "^1.4.4",
+        "react-devtools-inline": "4.4.0",
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
+      }
+    },
     "@esbuild/android-arm": {
       "version": "0.17.8",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.8.tgz",
@@ -15178,6 +15837,55 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@lezer/common": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
+    },
+    "@lezer/css": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.3.tgz",
+      "integrity": "sha512-SjSM4pkQnQdJDVc80LYzEaMiNy9txsFbI7HsMgeVF28NdLaAdHNtQ+kB/QqDUzRBV/75NTXjJ/R5IdC8QQGxMg==",
+      "requires": {
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/highlight": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "@lezer/html": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.5.tgz",
+      "integrity": "sha512-pUX9Y2HJiFGQdkDfLjN8dwR8jSxz/XYY/JmUiaoEAb+kvw0ZU63hRe0+k04fbyvg1208R2EltJ1v7IUHE0G1NA==",
+      "requires": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/javascript": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.4.tgz",
+      "integrity": "sha512-0BiBjpEcrt2IXrIzEAsdTLylrVhGHRqVQL3baTBx1sf4qewjIvhG1/pTUumu7W/7YR0AASjLQOQxFmo5EvNmzQ==",
+      "requires": {
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "@lezer/lr": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
+      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
+      "requires": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -15348,6 +16056,26 @@
         "fastq": "^1.6.0"
       }
     },
+    "@open-draft/deferred-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz",
+      "integrity": "sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA=="
+    },
+    "@react-hook/intersection-observer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz",
+      "integrity": "sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==",
+      "requires": {
+        "@react-hook/passive-layout-effect": "^1.2.0",
+        "intersection-observer": "^0.10.0"
+      }
+    },
+    "@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "requires": {}
+    },
     "@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -15371,6 +16099,11 @@
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "@stitches/core": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
+      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg=="
     },
     "@swc/helpers": {
       "version": "0.5.1",
@@ -15594,6 +16327,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
+    },
+    "@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -15985,6 +16723,11 @@
       "dev": true,
       "requires": {}
     },
+    "anser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.1.1.tgz",
+      "integrity": "sha512-nqLm4HxOTpeLOxcmB3QWmV5TcDFhW9y/fyQ+hivtDFcK4OQ+pQ5fzPnXHM1Mfcm0VkLtvVi1TCPr++Qy0Q/3EQ=="
+    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -16219,6 +16962,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -16301,6 +17049,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -16488,6 +17245,11 @@
         "clsx": "1.2.1"
       }
     },
+    "clean-set": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.2.tgz",
+      "integrity": "sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug=="
+    },
     "client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -16554,6 +17316,11 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
+    },
+    "codesandbox-import-util-types": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/codesandbox-import-util-types/-/codesandbox-import-util-types-2.2.3.tgz",
+      "integrity": "sha512-Qj00p60oNExthP2oR3vvXmUGjukij+rxJGuiaKM6tyUmSyimdZsqHI/TUvFFClAffk9s7hxGnQgWQ8KCce27qQ=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -16740,6 +17507,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -16810,6 +17582,15 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "data-urls": {
       "version": "2.0.0",
@@ -17149,6 +17930,35 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
     "esbuild": {
       "version": "0.17.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.8.tgz",
@@ -17183,6 +17993,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "escape-carriage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/escape-carriage/-/escape-carriage-1.3.1.tgz",
+      "integrity": "sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -17331,6 +18146,7 @@
         "next": "^13.4.4",
         "react": "*",
         "react-dom": "*",
+        "rehype-mdx-code-props": "^1.0.0",
         "remark-gfm": "^3.0.1",
         "swingset": "file:../../packages/swingset",
         "swingset-theme-hashicorp": "file:../../packages/swingset-theme-hashicorp"
@@ -17412,6 +18228,21 @@
         "jest-matcher-utils": "^29.5.0",
         "jest-message-util": "^29.5.0",
         "jest-util": "^29.5.0"
+      }
+    },
+    "ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "requires": {
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
       }
     },
     "extend": {
@@ -17803,6 +18634,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -17861,6 +18697,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "intersection-observer": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
+      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ=="
     },
     "is-alphabetical": {
       "version": "2.0.1",
@@ -19911,6 +20752,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
+    },
     "magic-string": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
@@ -20747,6 +21593,11 @@
         "zod": "3.21.4"
       }
     },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -20876,6 +21727,11 @@
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
       "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
       "dev": true
+    },
+    "outvariant": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw=="
     },
     "p-filter": {
       "version": "2.1.0",
@@ -21303,6 +22159,15 @@
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "dev": true
     },
+    "prism-react-renderer": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.6.tgz",
+      "integrity": "sha512-ERzmAI5UvrcTw5ivfEG20/dYClAsC84eSED5p9X3oKpm0xPV4A5clFK1mp7lPIdKmbLnQYsPTGiOI7WS6gWigw==",
+      "requires": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^1.2.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -21370,6 +22235,14 @@
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "react-devtools-inline": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
+      "integrity": "sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==",
+      "requires": {
+        "es6-symbol": "^3"
       }
     },
     "react-docgen": {
@@ -21528,6 +22401,19 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "functions-have-names": "^1.2.2"
+      }
+    },
+    "rehype-mdx-code-props": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-mdx-code-props/-/rehype-mdx-code-props-1.0.0.tgz",
+      "integrity": "sha512-NvHm7pTqIIfhpKmjNNizIIJzOcaRDvsAI2katLLylxX5DdhTw/sYKTKnvVZTungykXQglcYnlyVglsEuZ/jZxA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "hast-util-to-estree": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit-parents": "^5.0.0"
       }
     },
     "remark-gfm": {
@@ -22030,6 +22916,29 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "static-browser-server": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
+      "integrity": "sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==",
+      "requires": {
+        "@open-draft/deferred-promise": "^2.1.0",
+        "dotenv": "^16.0.3",
+        "mime-db": "^1.52.0",
+        "outvariant": "^1.3.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "16.3.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+          "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        }
+      }
+    },
     "std-env": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
@@ -22049,6 +22958,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "strict-event-emitter": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
+      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -22136,6 +23050,11 @@
       "requires": {
         "acorn": "^8.8.2"
       }
+    },
+    "style-mod": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "style-to-object": {
       "version": "0.4.1",
@@ -22268,12 +23187,14 @@
     "swingset-theme-hashicorp": {
       "version": "file:packages/swingset-theme-hashicorp",
       "requires": {
+        "@codesandbox/sandpack-react": "^2.6.9",
         "@hashicorp/flight-icons": "^2.14.0",
         "autoprefixer": "^10.4.14",
         "class-variance-authority": "^0.6.0",
         "next": "^13.4.4",
         "postcss": "^8.4.24",
         "postcss-cli": "^10.1.0",
+        "prism-react-renderer": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "swingset": "file:../swingset",
@@ -22770,6 +23691,11 @@
       "dev": true,
       "optional": true
     },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -23081,6 +24007,11 @@
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",

--- a/packages/swingset-theme-hashicorp/package.json
+++ b/packages/swingset-theme-hashicorp/package.json
@@ -39,7 +39,9 @@
     "tailwindcss": "^3.3.2"
   },
   "dependencies": {
+    "@codesandbox/sandpack-react": "^2.6.9",
     "@hashicorp/flight-icons": "^2.14.0",
-    "class-variance-authority": "^0.6.0"
+    "class-variance-authority": "^0.6.0",
+    "prism-react-renderer": "^2.0.6"
   }
 }

--- a/packages/swingset-theme-hashicorp/src/MDXComponents.tsx
+++ b/packages/swingset-theme-hashicorp/src/MDXComponents.tsx
@@ -1,7 +1,9 @@
 import { PropsTable } from './components/props-table'
 import { Heading } from './components/heading'
+import { LiveComponent } from './components/live-component'
+import { CodeBlock } from './components/code-block'
 
-export default {
+const MDXComponents = {
   h1: (props: any) => <Heading as="h1" {...props} />,
   h2: (props: any) => <Heading as="h2" {...props} />,
   h3: (props: any) => <Heading as="h3" {...props} />,
@@ -9,6 +11,10 @@ export default {
   h5: (props: any) => <Heading as="h5" {...props} />,
   h6: (props: any) => <Heading as="h6" {...props} />,
   p: (props: any) => <p className="ss-my-4" {...props} />,
-  pre: (props: any) => <pre className="ss-my-4" {...props} />,
+  pre: (props: any) => <CodeBlock {...props} />,
   PropsTable,
+  LiveComponent,
+  CodeBlock,
 }
+
+export default MDXComponents

--- a/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
@@ -1,22 +1,19 @@
 'use client' //Library calls hooks internally
 import { Highlight, themes } from 'prism-react-renderer'
 import { parseCode, parseLanguage } from './helpers'
-import { Language, MDXPreClass } from '@/types'
+import { MDXPreClass, MDXPreElement } from '@/types'
 import { CopyButton } from './copy-button'
 
-type CodeBlockProps = {
-  filePath: `${string}.${Language}`
-  children: React.Component
+interface CodeBlockProps {
+  children: MDXPreElement
   className: MDXPreClass
 }
 
 function CodeBlock(props: CodeBlockProps) {
   const { children } = props
+
   const code = parseCode(children)
-  const { className } = children.props as typeof children.props & {
-    className: MDXPreClass
-  }
-  const language = parseLanguage(className || 'language-jsx')
+  const language = parseLanguage(children.props.className ?? 'language-jsx')
 
   return (
     <div className="ss-mb-6 ss-rounded-md ss-overflow-hidden ss-relative">

--- a/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
@@ -1,0 +1,46 @@
+'use client' //Library calls hooks internally
+import { Highlight, themes } from 'prism-react-renderer'
+import { parseCode, parseLanguage } from './helpers'
+import { Language, MDXPreClass } from '@/types'
+import { CopyButton } from './copy-button'
+
+type CodeBlockProps = {
+  filePath: `${string}.${Language}`
+  children: React.Component
+  className: MDXPreClass
+}
+
+function CodeBlock(props: CodeBlockProps) {
+  const { children } = props
+  const code = parseCode(children)
+  const { className } = children.props as typeof children.props & {
+    className: MDXPreClass
+  }
+  const language = parseLanguage(className || 'language-jsx')
+
+  return (
+    <div className="ss-mb-6 ss-rounded-md ss-overflow-hidden ss-relative">
+      <Highlight code={code} language={language} theme={themes.dracula}>
+        {({ className, style, tokens, getLineProps, getTokenProps }) => {
+          return (
+            <pre
+              className={className + 'ss-bg-black'}
+              style={{ ...style, padding: '12px' }}
+            >
+              {tokens.map((line, i) => (
+                <div key={i} {...getLineProps({ line })}>
+                  {line.map((token, key) => (
+                    <span key={key} {...getTokenProps({ token, className })} />
+                  ))}
+                </div>
+              ))}
+            </pre>
+          )
+        }}
+      </Highlight>
+      <CopyButton code={code} />
+    </div>
+  )
+}
+
+export { CodeBlock }

--- a/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
@@ -11,7 +11,6 @@ interface CodeBlockProps {
 
 function CodeBlock(props: CodeBlockProps) {
   const { children } = props
-
   const code = parseCode(children)
   const language = parseLanguage(children.props.className ?? 'language-jsx')
 

--- a/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/code-block.tsx
@@ -23,10 +23,7 @@ function CodeBlock(props: CodeBlockProps) {
       <Highlight code={code} language={language} theme={themes.dracula}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => {
           return (
-            <pre
-              className={className + 'ss-bg-black'}
-              style={{ ...style, padding: '12px' }}
-            >
+            <pre className={'ss-p-3'} style={{ ...style }}>
               {tokens.map((line, i) => (
                 <div key={i} {...getLineProps({ line })}>
                   {line.map((token, key) => (

--- a/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
@@ -22,7 +22,7 @@ function CopyButton({ code }: { code: string }) {
     }
   }, [isCopied])
 
-  const handleClick = useCallback<MouseEventHandler>(async () => {
+  const handleClick = useCallback(async () => {
     setIsCopied(true)
     if (!navigator?.clipboard) {
       console.error('Access to clipboard rejected!')

--- a/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
@@ -1,0 +1,54 @@
+'use client'
+import {
+  IconDuplicate16,
+  IconFileCheck16,
+} from '@hashicorp/flight-icons/svg-react'
+import type { MouseEventHandler } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { cx } from 'class-variance-authority'
+
+function CopyButton({ code }: { code: string }) {
+  const [isCopied, setIsCopied] = useState(false)
+
+  useEffect(() => {
+    if (!isCopied) return
+    const timerId = setTimeout(() => {
+      setIsCopied(false)
+    }, 2000)
+
+    return () => {
+      clearTimeout(timerId)
+    }
+  }, [isCopied])
+
+  const handleClick = useCallback<
+    MouseEventHandler<HTMLButtonElement>
+  >(async () => {
+    setIsCopied(true)
+    if (!navigator?.clipboard) {
+      console.error('Access to clipboard rejected!')
+    }
+    try {
+      await navigator.clipboard.writeText(code)
+    } catch {
+      console.error('Failed to copy!')
+    }
+  }, [code])
+
+  const Icon = isCopied ? IconFileCheck16 : IconDuplicate16
+
+  return (
+    <button
+      className={cx(
+        'ss-top-3 ss-absolute ss-right-4 ss-text-gray-200 ss-cursor-pointer hover:ss-backdrop-brightness-150  ss-border-[1px] ss-border-gray-200 ss-p-1 ss-rounded-md active:ss-backdrop-brightness-50 active:ss-scale-90',
+        isCopied &&
+          'ss-text-green-400 ss-border-green-400 hover:ss-text-green-400'
+      )}
+      onClick={handleClick}
+    >
+      <Icon />
+    </button>
+  )
+}
+
+export { CopyButton }

--- a/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
@@ -11,10 +11,11 @@ function CopyButton({ code }: { code: string }) {
   const [isCopied, setIsCopied] = useState(false)
 
   useEffect(() => {
+    const timeoutDuration = 2000
     if (!isCopied) return
     const timerId = setTimeout(() => {
       setIsCopied(false)
-    }, 2000)
+    }, timeoutDuration)
 
     return () => {
       clearTimeout(timerId)

--- a/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
@@ -41,7 +41,7 @@ function CopyButton({ code }: { code: string }) {
   return (
     <button
       className={cx(
-        'ss-top-3 ss-absolute ss-right-4 ss-text-gray-200 ss-cursor-pointer hover:ss-backdrop-brightness-150  ss-border-[1px] ss-border-gray-200 ss-p-1 ss-rounded-md active:ss-backdrop-brightness-50 active:ss-scale-90',
+        'ss-top-3 ss-absolute ss-right-3 ss-text-gray-200 ss-cursor-pointer hover:ss-backdrop-brightness-150  ss-border-[1px] ss-border-gray-200 ss-p-1 ss-rounded-md active:ss-backdrop-brightness-50 active:ss-scale-90',
         isCopied &&
           'ss-text-green-400 ss-border-green-400 hover:ss-text-green-400'
       )}

--- a/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/copy-button.tsx
@@ -22,9 +22,7 @@ function CopyButton({ code }: { code: string }) {
     }
   }, [isCopied])
 
-  const handleClick = useCallback<
-    MouseEventHandler<HTMLButtonElement>
-  >(async () => {
+  const handleClick = useCallback<MouseEventHandler>(async () => {
     setIsCopied(true)
     if (!navigator?.clipboard) {
       console.error('Access to clipboard rejected!')

--- a/packages/swingset-theme-hashicorp/src/components/code-block/helpers.ts
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/helpers.ts
@@ -1,0 +1,31 @@
+import { Language, MDXPreClass } from '@/types'
+
+export const parseCode = (children: React.Component): string | never => {
+  if (typeof children === 'string') {
+    return (children as string).trimEnd()
+  }
+
+  if ('children' in children.props) {
+    return parseCode(children.props.children as React.Component)
+  }
+
+  //TODO: Link to README.md
+  throw Error('Unable to Find valid <CodeBlock/> component. See docs:')
+}
+
+export const parseLanguage = (langString: MDXPreClass): Language | never => {
+  const MDXprefix = 'language-'
+  const lang = langString.replace(MDXprefix, '')
+
+  if (isSupportedLanguage(lang)) {
+    return lang as Language
+  }
+
+  throw new Error(
+    `Expected (js | ts | jsx | tsx) in your CodeBlock meta data. Received ${lang}`
+  )
+}
+
+const isSupportedLanguage = (lang: string): true | false => {
+  return lang === 'js' || lang === 'jsx' || lang === 'ts' || lang === 'tsx'
+}

--- a/packages/swingset-theme-hashicorp/src/components/code-block/helpers.ts
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/helpers.ts
@@ -1,19 +1,11 @@
-import { Language, MDXPreClass } from '@/types'
+import { Language, MDXPreClass, MDXPreElement } from '@/types'
 
-export const parseCode = (children: React.Component): string | never => {
-  if (typeof children === 'string') {
-    return (children as string).trimEnd()
-  }
-
-  if ('children' in children.props) {
-    return parseCode(children.props.children as React.Component)
-  }
-
-  //TODO: Link to README.md
-  throw Error('Unable to Find valid <CodeBlock/> component. See docs:')
+export const parseCode = (toParse: MDXPreElement | string): string => {
+  if (typeof toParse === 'string') return toParse.trimEnd()
+  return toParse.props.children.trimEnd()
 }
 
-export const parseLanguage = (langString: MDXPreClass): Language | never => {
+export const parseLanguage = (langString: MDXPreClass): Language => {
   const MDXprefix = 'language-'
   const lang = langString.replace(MDXprefix, '')
 
@@ -26,6 +18,6 @@ export const parseLanguage = (langString: MDXPreClass): Language | never => {
   )
 }
 
-const isSupportedLanguage = (lang: string): true | false => {
+const isSupportedLanguage = (lang: string): boolean => {
   return lang === 'js' || lang === 'jsx' || lang === 'ts' || lang === 'tsx'
 }

--- a/packages/swingset-theme-hashicorp/src/components/code-block/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/index.tsx
@@ -1,0 +1,3 @@
+import { CodeBlock } from './code-block'
+
+export { CodeBlock }

--- a/packages/swingset-theme-hashicorp/src/components/code-block/theme.ts
+++ b/packages/swingset-theme-hashicorp/src/components/code-block/theme.ts
@@ -1,0 +1,27 @@
+export const CustomTheme = {
+  colors: {
+    accent: 'inherit',
+    base: 'inherit',
+    clickable: 'inherit',
+    disabled: 'inherit',
+    error: 'inherit',
+    errorSurface: 'inherit',
+    hover: 'inherit',
+    surface1: 'inherit',
+    surface2: 'inherit',
+    surface3: 'inherit',
+    warning: 'inherit',
+    warningSurface: 'inherit',
+  },
+  syntax: {
+    plain: 'inherit',
+    comment: 'inherit',
+    keyword: 'inherit',
+    tag: 'inherit',
+    punctuation: 'inherit',
+    definition: 'inherit',
+    property: 'inherit',
+    static: 'inherit',
+    string: 'inherit',
+  },
+}

--- a/packages/swingset-theme-hashicorp/src/components/live-component/code-theme.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/code-theme.tsx
@@ -1,0 +1,44 @@
+import { SandpackTheme } from '@codesandbox/sandpack-react/types'
+
+const sandpackTheme: SandpackTheme = {
+  colors: {
+    surface1: '#011627',
+    surface2: '#243b4c',
+    surface3: '#112331',
+    clickable: '#6988a1',
+    base: '#808080',
+    disabled: '#4D4D4D',
+    hover: '#c5e4fd',
+    accent: '#c5e4fd',
+    error: '#ffcdca',
+    errorSurface: '#811e18',
+  },
+  syntax: {
+    plain: '#d6deeb',
+    comment: {
+      color: '#999999',
+      fontStyle: 'italic',
+    },
+    keyword: {
+      color: '#c792ea',
+      fontStyle: 'italic',
+    },
+    tag: '#7fdbca',
+    punctuation: '#7fdbca',
+    definition: '#82aaff',
+    property: {
+      color: '#addb67',
+      fontStyle: 'italic',
+    },
+    static: '#f78c6c',
+    string: '#ecc48d',
+  },
+  font: {
+    body: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    mono: '"Fira Mono", "DejaVu Sans Mono", Menlo, Consolas, "Liberation Mono", Monaco, "Lucida Console", monospace',
+    size: '13px',
+    lineHeight: '20px',
+  },
+}
+
+export { sandpackTheme }

--- a/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
@@ -1,9 +1,10 @@
 import type { SandpackFile } from '@codesandbox/sandpack-react'
 import { parseCode } from '../code-block/helpers'
+import { MDXPreElement } from '@/types'
 
-export const getFileMap = (codeSnippets: React.ReactElement[]) => {
+export const getFileMap = (codeSnippets: MDXPreElement[]) => {
   const fileMap = codeSnippets.reduce(
-    (result: Record<string, SandpackFile>, codeSnippet: React.ReactElement) => {
+    (result: Record<string, SandpackFile>, codeSnippet) => {
       const { props } = codeSnippet
 
       const { filePath, hidden, active, children } = props

--- a/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
@@ -2,23 +2,18 @@ import type { SandpackFile } from '@codesandbox/sandpack-react'
 import { parseCode } from '../code-block/helpers'
 
 export const getFileMap = (codeSnippets: React.ReactElement[]) => {
-  //Handle Logic is only one codeSnippet is passed in...better DX
-
   const fileMap = codeSnippets.reduce(
     (result: Record<string, SandpackFile>, codeSnippet: React.ReactElement) => {
-      //TODO: Throw error to ensure this is only used with a <pre> tag
-
       const { props } = codeSnippet
 
       const { filePath, hidden, active, children } = props
 
       const code = parseCode(children)
-
+      //TODO: LINK TO README, CodeSandbox docs aren't very helpful here
       if (!filePath) {
         throw new Error(
           `<CodeBlock/> is missing a fileName prop. See docs: https://sandpack.codesandbox.io/docs/getting-started/usage#files `
         )
-        //TODO: LINK TO README, CodeSandbox docs aren't very helpful here
       }
 
       if (!!result[filePath]) {

--- a/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/get-file-map.ts
@@ -1,0 +1,41 @@
+import type { SandpackFile } from '@codesandbox/sandpack-react'
+import { parseCode } from '../code-block/helpers'
+
+export const getFileMap = (codeSnippets: React.ReactElement[]) => {
+  //Handle Logic is only one codeSnippet is passed in...better DX
+
+  const fileMap = codeSnippets.reduce(
+    (result: Record<string, SandpackFile>, codeSnippet: React.ReactElement) => {
+      //TODO: Throw error to ensure this is only used with a <pre> tag
+
+      const { props } = codeSnippet
+
+      const { filePath, hidden, active, children } = props
+
+      const code = parseCode(children)
+
+      if (!filePath) {
+        throw new Error(
+          `<CodeBlock/> is missing a fileName prop. See docs: https://sandpack.codesandbox.io/docs/getting-started/usage#files `
+        )
+        //TODO: LINK TO README, CodeSandbox docs aren't very helpful here
+      }
+
+      if (!!result[filePath]) {
+        throw new Error(
+          `File ${filePath} was defined multiple times. Each file snippet should have a unique path.`
+        )
+      }
+      result[filePath] = {
+        code,
+        hidden,
+        active,
+      }
+
+      return result
+    },
+    {}
+  )
+
+  return fileMap
+}

--- a/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
@@ -21,25 +21,23 @@ export function LiveComponent({ children, deps }: LiveComponentProps) {
   const dependencies = deps ?? undefined
 
   return (
-    <>
-      <SandpackProvider
-        template="react-ts"
-        files={fileMap}
-        theme={sandpackTheme}
-        customSetup={{ dependencies }}
-      >
-        <div className="flex ss-flex-col ss-w-full ss-border-4 ss-border-gray-300 ss-rounded-lg">
-          <SandpackPreview className="ss-h-[45vh] ss-max-h-[800px] ss-min-h-[280px]" />
-          <div className="ss-bg-black ss-overflow-y-scroll">
-            <SandpackCodeEditor
-              showInlineErrors
-              showTabs
-              showRunButton
-              wrapContent
-            />
-          </div>
+    <SandpackProvider
+      template="react-ts"
+      files={fileMap}
+      theme={sandpackTheme}
+      customSetup={{ dependencies }}
+    >
+      <div className="flex ss-flex-col ss-w-full ss-border-4 ss-border-gray-300 ss-rounded-lg">
+        <SandpackPreview className="ss-h-[45vh] ss-max-h-[800px] ss-min-h-[280px]" />
+        <div className="ss-bg-black ss-overflow-y-scroll">
+          <SandpackCodeEditor
+            showInlineErrors
+            showTabs
+            showRunButton
+            wrapContent
+          />
         </div>
-      </SandpackProvider>
-    </>
+      </div>
+    </SandpackProvider>
   )
 }

--- a/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
@@ -1,31 +1,29 @@
 'use client'
 import {
   SandpackProvider,
-  SandpackLayout,
   SandpackCodeEditor,
   SandpackPreview,
 } from '@codesandbox/sandpack-react'
 import { Children } from 'react'
 import { getFileMap } from './get-file-map'
 import { sandpackTheme } from './code-theme'
+import { MDXPreElement } from '@/types'
 
 type LiveComponentProps = {
-  children: string[]
+  children: MDXPreElement
   deps?: Record<string, string>
 }
 
 export function LiveComponent({ children, deps }: LiveComponentProps) {
-  const codeSnippets = Children.toArray(children) as React.ReactElement[]
-  const fileMap = getFileMap(codeSnippets)
-
-  const dependencies = deps ?? undefined
+  const codeBlocks = Children.toArray(children)
+  const fileMap = getFileMap(codeBlocks as MDXPreElement[])
 
   return (
     <SandpackProvider
       template="react-ts"
       files={fileMap}
       theme={sandpackTheme}
-      customSetup={{ dependencies }}
+      customSetup={{ dependencies: deps }}
     >
       <div className="flex ss-flex-col ss-w-full ss-border-4 ss-border-gray-300 ss-rounded-lg">
         <SandpackPreview className="ss-h-[45vh] ss-max-h-[800px] ss-min-h-[280px]" />

--- a/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
@@ -1,0 +1,48 @@
+'use client'
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackPreview,
+} from '@codesandbox/sandpack-react'
+import { Children } from 'react'
+import { getFileMap } from './get-file-map'
+import { sandpackTheme } from './code-theme'
+
+type LiveComponentProps = {
+  children: string[]
+  deps?: Record<string, string>
+}
+
+export function LiveComponent({ children, deps }: LiveComponentProps) {
+  const codeSnippets = Children.toArray(children) as React.ReactElement[]
+  const fileMap = getFileMap(codeSnippets)
+
+  const dependencies = deps ?? undefined
+
+  return (
+    <>
+      <SandpackProvider
+        template="react-ts"
+        files={fileMap}
+        theme={sandpackTheme}
+        customSetup={{ dependencies }}
+      >
+        <div className="flex ss-flex-col ss-w-full ss-border-4 ss-border-gray-300 ss-rounded-lg">
+          <SandpackPreview className="ss-h-[45vh] ss-max-h-[800px] ss-min-h-[280px]" />
+          <div className="ss-bg-black ss-overflow-y-scroll">
+            <SandpackCodeEditor
+              showInlineErrors
+              showTabs
+              showRunButton
+              wrapContent
+            />
+          </div>
+        </div>
+      </SandpackProvider>
+    </>
+  )
+}
+/**
+ * The default layout styles for Sandpack
+ */

--- a/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/live-component/index.tsx
@@ -43,6 +43,3 @@ export function LiveComponent({ children, deps }: LiveComponentProps) {
     </>
   )
 }
-/**
- * The default layout styles for Sandpack
- */

--- a/packages/swingset-theme-hashicorp/src/types.ts
+++ b/packages/swingset-theme-hashicorp/src/types.ts
@@ -1,3 +1,11 @@
 export type Language = 'ts' | 'js' | 'jsx' | 'tsx'
 
 export type MDXPreClass = `language-${Language}`
+
+export type MDXPreElement = React.ReactElement<{
+  children: string
+  className?: MDXPreClass
+  filePath?: string
+  hidden: boolean
+  active?: boolean
+}>

--- a/packages/swingset-theme-hashicorp/src/types.ts
+++ b/packages/swingset-theme-hashicorp/src/types.ts
@@ -1,0 +1,3 @@
+export type Language = 'ts' | 'js' | 'jsx' | 'tsx'
+
+export type MDXPreClass = `language-${Language}`

--- a/packages/swingset-theme-hashicorp/tsconfig.json
+++ b/packages/swingset-theme-hashicorp/tsconfig.json
@@ -12,7 +12,11 @@
     "lib": ["es2022", "dom"],
     "moduleResolution": "node",
     "types": ["vitest/globals", "webpack-env"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["dist/**/*"]


### PR DESCRIPTION
🎟️ [Asana Task](https://app.asana.com/0/1100423001970639/1204807557661941/f)
👀 [Preview](https://swingset-example-git-preslive-comp-sandpack-hashicorp.vercel.app/swingset)

# New `LiveComponent` 🚀
This PR adds two new components to `swingset-theme-hashicorp` and exposes them for use in `.mdx` files to any Next.js application that uses App Router + Swingset

## New Components

### `<CodeBlock/>`

This is the component rendered for the mdx `<pre>` tag i.e. 
````markdown
```js
/* Code here */
```
````
However it can also be used directly with a string.
```jsx
<CodeBlock {...props}>
{`
export default function App() {
    const data = "World"
    return <p>Hello, {data}</p>
}
`}
</Codeblock>
```

It's currently using the `prism-react-renderer` to facilitate syntax highlighting however it's using an arbitrary theme, a follow up Issue to this PR should unify the highlighting between both this and the `LiveComponent`

>**Note**
> Even though this PR introduces theme files for both the `LiveComponent` and `CodeBlock` it is not concerned with  styling / syntax highlighting. These files just serve as templates and proof of concepts that we can use a custom theme later on.

### `<LiveComponent/>`

This is the wrapper around `@codesandbox/sandpack-react`

Instead of using `Sandpack` directly, the `LiveComponent` wrapper
- Restricts `props` to functionality only our team needs
- Makes API and MDX usage more intuitive by allowing files to be composed of mutiple `<CodeBlock/>`s

These features are done using helper functions in the `.../code-block` directory



### Packages introduced

#### [`@codesandbox/sandpack-react`](https://github.com/codesandbox/sandpack)
Our `LiveComponent` acts as a wrapper around this. The package is more actively maintained than `react-live`, our original solution. It's well adopted and has more in depth [documentation](https://sandpack.codesandbox.io/docs).

#### [`rehype-mdx-code-props`](https://github.com/codesandbox/sandpack)
This was the solution recommended on the MDX [documentation](https://mdxjs.com/guides/syntax-highlighting/#syntax-highlighting-with-the-meta-field) for passing `props` to code blocks. [See repo](https://github.com/remcohaszing/rehype-mdx-code-props)

#### [`react-prism-renderer`](https://github.com/codesandbox/sandpack)
Well maintained and first class react support so very low LOE. 
I attempted to use our already existing [`CodeBlock`](https://github.com/hashicorp/react-components/blob/main/packages/code-block/index.tsx), however there were SSR errors that broke the copy and prop integration functionality. Down the line we may want to adopt our already existing components instead of creating a new one, will open issue if merged.