### PR TITLE
New UI ✨

### DIFF
--- a/packages/swingset-theme-hashicorp/src/components/app-wrapper.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/app-wrapper.tsx
@@ -15,8 +15,7 @@ export function AppWrapper({ children }: { children: ReactNode }) {
         <div
           className={cx(
             'ss-flex ss-flex-col ss-flex-grow ss-m-auto ss-max-w-5xl ss-mb-24 ss-transition-all',
-            !isOpen && 'ss-w-2/3',
-            isOpen && 'ss-w-1/2'
+            isOpen ? 'ss-w-1/2' : 'ss-w-2/3'
           )}
         >
           {children}

--- a/packages/swingset-theme-hashicorp/src/components/app-wrapper.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/app-wrapper.tsx
@@ -9,18 +9,19 @@ export function AppWrapper({ children }: { children: ReactNode }) {
   const toggle = () => setIsOpen((curr) => !curr)
 
   return (
-    <>
+    <div className="ss-h-[100vh] ss-w-full">
       <SideNavigation categories={categories} isOpen={isOpen} toggle={toggle} />
-      <main
-        className={cx(
-          'ss-py-10 ss-flex ss-flex-col ss-flex-grow ss-h-full ss-transition-all ss-px-4 sm:ss-m-0',
-          isOpen && 'lg:ss-mx-64 xl:ss-mx-72 2xl:ss-mx-[460px]'
-        )}
-      >
-        <div className="ss-flex ss-flex-col ss-flex-grow md:ss-px-8">
+      <main className="ss-h-full ss-w-full ss-overflow-auto ss-m-auto">
+        <div
+          className={cx(
+            'ss-flex ss-flex-col ss-flex-grow ss-m-auto ss-max-w-5xl ss-mb-24 ss-transition-all',
+            !isOpen && 'ss-w-2/3',
+            isOpen && 'ss-w-1/2'
+          )}
+        >
           {children}
         </div>
       </main>
-    </>
+    </div>
   )
 }

--- a/packages/swingset-theme-hashicorp/src/components/nav-bar/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/nav-bar/index.tsx
@@ -1,0 +1,37 @@
+import { Logo } from './logo'
+import Link from 'next/link'
+import { IconGithub24 } from '@hashicorp/flight-icons/svg-react'
+
+function NavBar() {
+  return (
+    <header className="ss-w-full ss-border-b-2 ss-border-faint">
+      <nav>
+        <ul className="ss-px-6 ss-p-2 ss-flex ss-items-center ss-w-full ss-justify-between">
+          <li className="ss-flex-1">
+            <Logo />
+          </li>
+          <li className="ss-flex-1 ss-text-center">
+            <Link
+              href={'/swingset'}
+              className="ss-font-semibold ss-text-dark hover:ss-text-action"
+            >
+              About
+            </Link>
+          </li>
+
+          <li className="ss-flex-1">
+            <Link
+              href={'https://github.com/hashicorp/swingset'}
+              className="ss-font-semibold ss-text-dark hover:ss-text-action"
+              target="_blank"
+            >
+              <IconGithub24 className="ss-ml-auto" />
+            </Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  )
+}
+
+export { NavBar }

--- a/packages/swingset-theme-hashicorp/src/components/nav-bar/logo.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/nav-bar/logo.tsx
@@ -1,0 +1,21 @@
+import { IconHashicorp24 } from '@hashicorp/flight-icons/svg-react'
+
+function Logo() {
+  return (
+    <section className="ss-flex ss-items-center ss-gap-4">
+      <picture className="ss-border-2 ss-h-full ss-p-2 ss-border-faint ss-rounded-lg">
+        <IconHashicorp24 />
+      </picture>
+      <div>
+        <p className="ss-font-semibold ss-text-dark ss-my-0 ss-text-sm">
+          HashiCorp
+        </p>
+        <p className="ss-font-extralight ss-leading-4 ss-my-0 ss-text-sm">
+          Web Presence
+        </p>
+      </div>
+    </section>
+  )
+}
+
+export { Logo }

--- a/packages/swingset-theme-hashicorp/src/components/side-nav/category.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/side-nav/category.tsx
@@ -10,8 +10,8 @@ function Category({
   items: NavigationNode[]
 }) {
   return (
-    <li className="ss-list-none">
-      <section className="ss-mb-4">
+    <li className="ss-list-none ss-w-full">
+      <section className="ss-mb-4 ss-px-6">
         <CategoryHeading>{title}</CategoryHeading>
         <ComponentList items={items} />
       </section>
@@ -21,7 +21,7 @@ function Category({
 //Swap this out for already existing heading && Enquire about semantics, https://helios.hashicorp.design/components/application-state uses <div>
 function CategoryHeading({ children }: { children: string }) {
   return (
-    <div className="ss-capitalize ss-text-xs ss-font-semibold ss-leading-6 ss-text-primary ss-border-b ss-border-faint ss-pb-2">
+    <div className="ss-capitalize ss-font-semibold ss-leading-6 ss-text-primary ss-border-b ss-border-faint ss-pb-2">
       {children}
     </div>
   )

--- a/packages/swingset-theme-hashicorp/src/components/side-nav/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/side-nav/index.tsx
@@ -24,24 +24,15 @@ function SideNavigation({ categories, isOpen, toggle }: SideNavBarProps) {
       <aside
         aria-hidden={!isOpen}
         className={cx(
-          'ss-hidden lg:ss-fixed lg:ss-inset-y-0 lg:ss-z-50 lg:ss-flex lg:ss-flex-col lg:ss-w-72 ss-transition-transform',
-          !isOpen && 'ss--translate-x-full ss-invisible'
+          'ss-hidden lg:ss-z-50 lg:ss-flex lg:ss-flex-col ss-w-1/5 ss-max-w-md ss-transition-transform ss-m-0 ss-h-full ss-fixed',
+          !isOpen && 'ss--translate-x-[85%]'
         )}
       >
-        <div className="ss-flex ss-grow ss-flex-col ss-gap-y-5 ss-overflow-y-auto ss-border-r ss-border-faint ss-bg-surface-faint ss-px-6 ss-py-10">
-          <div className="ss-flex ss-shrink-0 ss-items-center">
-            <Link
-              href="/swingset"
-              className="ss-tracking-widest ss-text-sm ss-uppercase ss-font-bold ss-no-underline ss-text-faint ss-transition-colors hover:ss-text-action"
-            >
-              Swingset
-            </Link>
-          </div>
-
-          <nav>{renderedCategories}</nav>
-        </div>
+        <ToggleButton isOpen={isOpen} toggle={toggle} />
+        <nav className="ss-flex ss-grow ss-flex-col ss-gap-y-5 ss-overflow-y-auto ss-border-r ss-border-r-faint ss-py-10">
+          {isOpen && renderedCategories}
+        </nav>
       </aside>
-      <ToggleButton isOpen={isOpen} toggle={toggle} />
     </>
   )
 }

--- a/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
@@ -16,8 +16,8 @@ export function ToggleButton({ toggle, isOpen }: ToggleButtonProps) {
       aria-label={ariaLabel}
       className={cx(
         'ss-hidden ss-absolute lg:ss-block hover:ss-text-action ss-ml-1 ss-p-1 ss-transition-all ss-top-3 ss-right-3',
-        isOpen && 'ss--rotate-90',
-        !isOpen && 'ss-rotate-90'
+        !isOpen && 'ss--rotate-90',
+        isOpen && 'ss-rotate-90'
       )}
       onClick={toggle}
     >

--- a/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
@@ -16,8 +16,7 @@ export function ToggleButton({ toggle, isOpen }: ToggleButtonProps) {
       aria-label={ariaLabel}
       className={cx(
         'ss-hidden ss-absolute lg:ss-block hover:ss-text-action ss-ml-1 ss-p-1 ss-transition-all ss-top-3 ss-right-3',
-        !isOpen && 'ss--rotate-90',
-        isOpen && 'ss-rotate-90'
+        isOpen ? 'ss-rotate-90' : 'ss--rotate-90'
       )}
       onClick={toggle}
     >

--- a/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
+++ b/packages/swingset-theme-hashicorp/src/components/side-nav/toggle-button.tsx
@@ -1,4 +1,4 @@
-import { IconChevronLeft24 } from '@hashicorp/flight-icons/svg-react/chevron-left-24'
+import { IconBottom24 } from '@hashicorp/flight-icons/svg-react/bottom-24'
 import { cx } from 'class-variance-authority'
 
 type ToggleButtonProps = {
@@ -10,16 +10,18 @@ export function ToggleButton({ toggle, isOpen }: ToggleButtonProps) {
   const ariaLabel = isOpen
     ? 'Collapse navigation menu'
     : 'Expand navigation menu'
+
   return (
     <button
       aria-label={ariaLabel}
       className={cx(
-        'ss-bg-surface-faint ss-hidden lg:ss-block hover:ss-bg-surface-action ss-opacity-70 hover:ss-text-action ss-border-2 ss-border-faint hover:ss-border-action ss-ml-1 ss-p-1 ss-rounded-full hover:ss-shadow-lg ss-transition-all ss-shadow-sm ss-fixed ss-top-6 ss-left-72',
-        !isOpen && 'ss--translate-x-72'
+        'ss-hidden ss-absolute lg:ss-block hover:ss-text-action ss-ml-1 ss-p-1 ss-transition-all ss-top-3 ss-right-3',
+        isOpen && 'ss--rotate-90',
+        !isOpen && 'ss-rotate-90'
       )}
       onClick={toggle}
     >
-      <IconChevronLeft24 className={cx(!isOpen && 'ss--rotate-180')} />
+      <IconBottom24 />
     </button>
   )
 }

--- a/packages/swingset-theme-hashicorp/src/index.tsx
+++ b/packages/swingset-theme-hashicorp/src/index.tsx
@@ -2,6 +2,7 @@
 import '../style.css'
 import React from 'react'
 import { AppWrapper } from './components/app-wrapper'
+import { NavBar } from './components/nav-bar'
 import { meta } from 'swingset/meta'
 import Page from './page'
 
@@ -12,7 +13,8 @@ export default function SwingsetLayout({
 }) {
   return (
     <html lang="en" className="ss-h-full">
-      <body className="ss-h-full flex flex-col ss-items-center">
+      <body className="ss-overflow-hidden">
+        <NavBar />
         <AppWrapper>{children}</AppWrapper>
         <script
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
[Preview](https://swingset-example-git-presnavdesign-hashicorp.vercel.app/swingset)

# Summary
This PR does the following

- Adds a navigation bar at the top per design spec
- Changes `Chevron` into `Bottom` icon per design spec
- Restricts `max-width` of main content 

## Why
Quick explanation for the last one, when talking to @benjamin-gage we were discussing that the main reason for full-screen in the first place was so that someone can have more pleasant usage with `LiveComponent`.

Since now it links to Codesandbox, a fully equipped online IDE. Having full screen for reading content would likely just make the documentation harder to read.
